### PR TITLE
Add basic upgrade support to mysql-init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,10 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: secretmysql
   mysql-init:
-    image: monasca/mysql-init:1.1.0
+    image: monasca/mysql-init:1.4.0
     environment:
       MYSQL_INIT_DISABLE_REMOTE_ROOT: "true"
-      MYSQL_INIT_RANDOM_PASSWORD: "true"
+      MYSQL_INIT_RANDOM_PASSWORD: "false"
 
   keystone:
     image: monasca/keystone:1.0.7

--- a/mysql-init/Dockerfile
+++ b/mysql-init/Dockerfile
@@ -1,5 +1,9 @@
 from alpine:3.5
 
+env SCHEMA_MAJOR_REV=1 \
+  SCHEMA_MINOR_REV=4 \
+  SCHEMA_PATCH_REV=0
+
 run apk add --no-cache mysql-client pwgen py2-jinja2
 copy init.sh template.py disable-remote-root.sql /
 copy mysql-init.d /mysql-init.d/

--- a/mysql-init/build.yml
+++ b/mysql-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/mysql-init
 variants:
   - tag: latest
     aliases:
-      - :1.3.0
-      - :1.3
+      - :1.4.0
+      - :1.4
       - :1

--- a/mysql-init/init.sh
+++ b/mysql-init/init.sh
@@ -7,11 +7,13 @@ MYSQL_INIT_HOST=${MYSQL_INIT_HOST:-"mysql"}
 MYSQL_INIT_PORT=${MYSQL_INIT_PORT:-"3306"}
 MYSQL_INIT_USERNAME=${MYSQL_INIT_USERNAME:-"root"}
 MYSQL_INIT_PASSWORD=${MYSQL_INIT_PASSWORD:-"secretmysql"}
+MYSQL_INIT_SCHEMA_DATABASE=${MYSQL_INIT_DATABASE:-"mysql_init_schema"}
 
 MYSQL_INIT_WAIT_RETRIES=${MYSQL_INIT_WAIT_RETRIES:-"24"}
 MYSQL_INIT_WAIT_DELAY=${MYSQL_INIT_WAIT_DELAY:-"5"}
 
 USER_SCRIPTS="/mysql-init.d"
+UPGRADE_SCRIPTS="/mysql-upgrade.d"
 
 echo "Waiting for MySQL to become available..."
 success="false"
@@ -38,56 +40,73 @@ if [ "$success" != "true" ]; then
     exit 1
 fi
 
-set -e
+query="select major, minor, patch from schema_version order by id desc limit 1;"
+version=$(echo "$query" | mysql \
+    --host="$MYSQL_INIT_HOST" \
+    --user="$MYSQL_INIT_USERNAME" \
+    --port=$MYSQL_INIT_PORT \
+    --password="$MYSQL_INIT_PASSWORD" \
+    --silent \
+    $MYSQL_INIT_SCHEMA_DATABASE)
+if [ $? -eq 0 ]; then
+  echo "MySQL has already been initialized! Current version: $version"
 
-for f in $USER_SCRIPTS/*.sql.j2; do
-  if [ -e "$f" ]; then
-    echo "Applying template: $f"
-    python /template.py "$f" "$USER_SCRIPTS/$(basename "$f" .j2)"
+  # TODO apply upgrades
+  echo "Updating not yet implemented!"
+else
+  echo "MySQL has not yet been initialized. Initial schemas will be applied."
+
+  set -e
+
+  for f in $USER_SCRIPTS/*.sql.j2; do
+    if [ -e "$f" ]; then
+      echo "Applying template: $f"
+      python /template.py "$f" "$USER_SCRIPTS/$(basename "$f" .j2)"
+    fi
+  done
+
+  for f in $USER_SCRIPTS/*.sql; do
+    if [ -e "$f" ]; then
+      echo "Running script: $f"
+      mysql --host="$MYSQL_INIT_HOST" \
+          --user="$MYSQL_INIT_USERNAME" \
+          --port=$MYSQL_INIT_PORT \
+          --password="$MYSQL_INIT_PASSWORD" < "$f"
+    fi
+  done
+
+  if [ -n "$MYSQL_INIT_SET_PASSWORD" ]; then
+    echo "Updating password for $MYSQL_INIT_USERNAME..."
+
+    set +x
+    mysqladmin password \
+        --host="$MYSQL_INIT_HOST" \
+        --port=$MYSQL_INIT_PORT \
+        --user="$MYSQL_INIT_USERNAME" \
+        --password="$MYSQL_INIT_PASSWORD" \
+        "$MYSQL_INIT_SET_PASSWORD"
+  elif [ "$MYSQL_INIT_RANDOM_PASSWORD" = "true" ]; then
+    echo "Resetting $MYSQL_INIT_USERNAME password..."
+
+    set +x
+    pw=$(pwgen -1 32)
+    mysqladmin password \
+        --host="$MYSQL_INIT_HOST" \
+        --port=$MYSQL_INIT_PORT \
+        --user="$MYSQL_INIT_USERNAME" \
+        --password="$MYSQL_INIT_PASSWORD" \
+        "$pw"
+    echo "GENERATED $MYSQL_INIT_USERNAME PASSWORD: $pw"
+    MYSQL_INIT_PASSWORD="$pw"
   fi
-done
 
-for f in $USER_SCRIPTS/*.sql; do
-  if [ -e "$f" ]; then
-    echo "Running script: $f"
+  if [ "$MYSQL_INIT_DISABLE_REMOTE_ROOT" = "true" ]; then
+    echo "Disabling remote root login..."
     mysql --host="$MYSQL_INIT_HOST" \
         --user="$MYSQL_INIT_USERNAME" \
         --port=$MYSQL_INIT_PORT \
-        --password="$MYSQL_INIT_PASSWORD" < "$f"
+        --password="$MYSQL_INIT_PASSWORD" < /disable-remote-root.sql
   fi
-done
-
-if [ -n "$MYSQL_INIT_SET_PASSWORD" ]; then
-  echo "Updating password for $MYSQL_INIT_USERNAME..."
-
-  set +x
-  mysqladmin password \
-      --host="$MYSQL_INIT_HOST" \
-      --port=$MYSQL_INIT_PORT \
-      --user="$MYSQL_INIT_USERNAME" \
-      --password="$MYSQL_INIT_PASSWORD" \
-      "$MYSQL_INIT_SET_PASSWORD"
-elif [ "$MYSQL_INIT_RANDOM_PASSWORD" = "true" ]; then
-  echo "Resetting $MYSQL_INIT_USERNAME password..."
-
-  set +x
-  pw=$(pwgen -1 32)
-  mysqladmin password \
-      --host="$MYSQL_INIT_HOST" \
-      --port=$MYSQL_INIT_PORT \
-      --user="$MYSQL_INIT_USERNAME" \
-      --password="$MYSQL_INIT_PASSWORD" \
-      "$pw"
-  echo "GENERATED $MYSQL_INIT_USERNAME PASSWORD: $pw"
-  MYSQL_INIT_PASSWORD="$pw"
-fi
-
-if [ "$MYSQL_INIT_DISABLE_REMOTE_ROOT" = "true" ]; then
-  echo "Disabling remote root login..."
-  mysql --host="$MYSQL_INIT_HOST" \
-      --user="$MYSQL_INIT_USERNAME" \
-      --port=$MYSQL_INIT_PORT \
-      --password="$MYSQL_INIT_PASSWORD" < /disable-remote-root.sql
 fi
 
 echo "mysql-init exiting successfully"

--- a/mysql-init/mysql-init.d/00-monasca.sql.j2
+++ b/mysql-init/mysql-init.d/00-monasca.sql.j2
@@ -17,8 +17,6 @@
 
 {% set db = MONASCA_DATABASE | default('mon') %}
 
-DROP DATABASE IF EXISTS `{{ db }}`;
-
 CREATE DATABASE IF NOT EXISTS `{{ db }}` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE `{{ db }}`;
 

--- a/mysql-init/mysql-init.d/00-monasca.sql.j2
+++ b/mysql-init/mysql-init.d/00-monasca.sql.j2
@@ -1,20 +1,20 @@
 /*
-* (C) Copyright 2015,2016 Hewlett Packard Enterprise Development LP
-* Copyright 2016 FUJITSU LIMITED
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-* implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * (C) Copyright 2015,2016,2017 Hewlett Packard Enterprise Development LP
+ * Copyright 2016 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
 */
+
 {% set db = MONASCA_DATABASE | default('mon') %}
 
 DROP DATABASE IF EXISTS `{{ db }}`;

--- a/mysql-init/mysql-init.d/99-version-schema.sql.j2
+++ b/mysql-init/mysql-init.d/99-version-schema.sql.j2
@@ -1,0 +1,21 @@
+/* (C) Copyright 2017 Hewlett Packard Enterprise Development LP */
+
+{% set db = MYSQL_INIT_SCHEMA_DATABASE | default('mysql_init_schema') %}
+
+create database if not exists `{{ db }}` default character set utf8mb4 collate utf8mb4_unicode_ci;
+use `{{ db }}`;
+
+create table if not exists `schema_version` (
+  `id` int not null auto_increment,
+  `major` int not null,
+  `minor` int not null,
+  `patch` int not null,
+  `updated_at` timestamp not null default current_timestamp,
+  primary key (id)
+);
+
+insert into `schema_version` (major, minor, patch) values (
+  {{ SCHEMA_MAJOR_REV }},
+  {{ SCHEMA_MINOR_REV }},
+  {{ SCHEMA_PATCH_REV }}
+);


### PR DESCRIPTION
This add very preliminary 'upgrade' support to mysql init. mysql-init
now automatically creates a schema version table and checks versions
during init. Eventually it will use this table to apply upgrades
sequentially based on the current installed schema version.

Note that actual upgrade logic will come in a future PR. This patch
is mainly intended to make mysql-init return successfully when run
against an existing database. If an existing version is found it will
print the version but will not process the `mysql-upgrades.d`
directory yet.