### PR TITLE
Add container to create Notifications and Alarm Definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     depends_on:
       - influxdb
 
+  alarms:
+    image: monasca/alarms:latest
+
   zookeeper:
     image: zookeeper:3.3
   kafka:

--- a/monasca-alarms/Dockerfile
+++ b/monasca-alarms/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.5
+
+ARG FORWARDER_REPO=https://github.hpe.com/UNCLE/monasca-forwarder
+ARG FORWARDER_BRANCH=master
+
+# To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
+# `docker build`
+ARG REBUILD=1
+
+ENV MONASCA_WAIT_FOR_API=true \
+  OS_PASSWORD=password \
+  OS_PROJECT_DOMAIN_NAME=Default \
+  OS_AUTH_URL=http://keystone:35357/v3/ \
+  OS_PROJECT_NAME=mini-mon \
+  OS_USERNAME=mini-mon \
+  OS_USER_DOMAIN_NAME=Default
+
+RUN apk add --no-cache \
+    python py2-pip py2-netaddr py2-yaml && \
+  apk add --no-cache --virtual build-dep \
+    git python-dev make g++ linux-headers && \
+  pip install python-monascaclient && \
+  rm -rf /root/.cache/pip && \
+  apk del build-dep
+
+COPY definitions.yml /config/definitions.yml
+COPY monasca_alarm_definition.py start.sh /
+CMD ["/start.sh"]

--- a/monasca-alarms/Dockerfile
+++ b/monasca-alarms/Dockerfile
@@ -1,8 +1,5 @@
 FROM alpine:3.5
 
-ARG FORWARDER_REPO=https://github.hpe.com/UNCLE/monasca-forwarder
-ARG FORWARDER_BRANCH=master
-
 # To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
 # `docker build`
 ARG REBUILD=1

--- a/monasca-alarms/README.md
+++ b/monasca-alarms/README.md
@@ -1,0 +1,43 @@
+monasca-alarms Dockerfile
+============================
+
+This image contains a container that can be used to create Monasca
+Notifications and Alarm Definitions.
+
+Tags
+----
+
+The images in this repository follow a few tagging conventions:
+
+ * `latest`: refers to the latest definitions container
+
+Usage
+-----
+
+To run, the python creation script needs to connect to a working Monasca API.
+
+In environments resembling the [official Kubernetes environment][1] the image
+does not require additional configuration parameters, and can be run like so:
+
+```bash
+docker run -it monasca/alarms:latest
+```
+
+Configuration
+-------------
+
+| Variable                 | Default                      | Description                      |
+|--------------------------|------------------------------|----------------------------------|
+| `MONASCA_WAIT_FOR_API`   | `true`                       | Ensure Monasca API is available  |
+| `OS_PASSWORD`            | `password`                   | Password for Keystone User       |
+| `OS_PROJECT_DOMAIN_NAME` | `Default`                    | User Project Domain Name         |
+| `OS_AUTH_URL`            | `http://keystone:35357/v3/`  | Keystone URL                     |
+| `OS_PROJECT_NAME`        | `mini-mon`                   | User Project Name                |
+| `OS_USERNAME`            | `mini-mon`                   | Keystone User Name               |
+| `OS_USER_DOMAIN_NAME`    | `Default`                    | Keystone User Domain Name        |
+
+The yaml file describing the Notifications and Alarm Definitions is available
+[in the repository][2].
+
+[1]: https://github.com/hpcloud-mon/monasca-docker/blob/master/k8s/
+[2]: https://github.com/hpcloud-mon/monasca-docker/blob/master/monasca-alarms/definitions.yml

--- a/monasca-alarms/build.yml
+++ b/monasca-alarms/build.yml
@@ -1,0 +1,5 @@
+repository: monasca/alarms
+variants:
+  - tag: 1.0.0
+    aliases:
+      - :latest

--- a/monasca-alarms/definitions.yml
+++ b/monasca-alarms/definitions.yml
@@ -1,0 +1,193 @@
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Default Notifications and Alarms
+#
+notifications:
+  - name: root email
+    type: email
+    address: root@localhost
+
+alarm_definitions:
+  - name: "Host Status"
+    description: "Alarms when the specified host is down or not reachable"
+    severity: "HIGH"
+    expression: "host_alive_status > 0"
+    match_by:
+      - "target_host"
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "HTTP Status"
+    description: >
+      "Alarms when the specified HTTP endpoint is down or not reachable"
+    severity: "HIGH"
+    expression: "http_status > 0"
+    match_by:
+      - "service"
+      - "component"
+      - "hostname"
+      - "url"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "CPU Usage"
+    description: "Alarms when CPU usage is high"
+    expression: "avg(cpu.idle_perc) < 10 times 3"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "High CPU IOWait"
+    description: "Alarms when CPU IOWait is high, possible slow disk issue"
+    expression: "avg(cpu.wait_perc) > 40 times 3"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Disk Inode Usage"
+    description: "Alarms when disk inode usage is high"
+    expression: "disk.inode_used_perc > 90"
+    match_by:
+      - "hostname"
+      - "device"
+    severity: "HIGH"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Disk Usage"
+    description: "Alarms when disk usage is high"
+    expression: "disk.space_used_perc > 90"
+    match_by:
+      - "hostname"
+      - "device"
+    severity: "HIGH"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Memory Usage"
+    description: "Alarms when memory usage is high"
+    severity: "HIGH"
+    expression: "avg(mem.usable_perc) < 10 times 3"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Network Errors"
+    description: >
+      "Alarms when either incoming or outgoing network errors are high"
+    severity: "MEDIUM"
+    expression: "net.in_errors_sec > 5 or net.out_errors_sec > 5"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Process Check"
+    description: "Alarms when the specified process is not running"
+    severity: "HIGH"
+    expression: "process.pid_count < 1"
+    match_by:
+      - "process_name"
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Crash Dump Count"
+    description: "Alarms when a crash directory is found"
+    severity: "MEDIUM"
+    expression: "crash.dump_count > 0"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "Monasca Agent Collection Time"
+    description: "Alarms when the elapsed time the Monasca Agent takes to \
+                    collect metrics is high"
+    expression: "avg(monasca.collection_time_sec) > 30 times 3"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "ZooKeeper Latency"
+    description: "Alarms when the ZooKeeper latency is high"
+    expression: "avg(zookeeper.avg_latency_sec) > 1 times 3"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "NTP Time Sync"
+    description: "Alarms when the NTP time offset is high"
+    expression: "ntp.offset > 5 or ntp.offset < -5"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email
+  - name: "NTP Connection Status"
+    description: "Alarms when the connection failed to the NTP server"
+    expression: "ntp.connection_status > 0"
+    match_by:
+      - "hostname"
+    alarm_actions:
+      - root email
+    ok_actions:
+      -  root email
+    undetermined_actions:
+      - root email

--- a/monasca-alarms/definitions.yml
+++ b/monasca-alarms/definitions.yml
@@ -33,7 +33,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "HTTP Status"
@@ -49,7 +49,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "CPU Usage"
@@ -60,7 +60,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "High CPU IOWait"
@@ -71,7 +71,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Disk Inode Usage"
@@ -84,7 +84,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Disk Usage"
@@ -97,7 +97,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Memory Usage"
@@ -107,7 +107,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Network Errors"
@@ -118,7 +118,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Process Check"
@@ -131,7 +131,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Crash Dump Count"
@@ -143,7 +143,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "Monasca Agent Collection Time"
@@ -155,7 +155,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "ZooKeeper Latency"
@@ -166,7 +166,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "NTP Time Sync"
@@ -177,7 +177,7 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email
   - name: "NTP Connection Status"
@@ -188,6 +188,6 @@ alarm_definitions:
     alarm_actions:
       - root email
     ok_actions:
-      -  root email
+      - root email
     undetermined_actions:
       - root email

--- a/monasca-alarms/monasca_alarm_definition.py
+++ b/monasca-alarms/monasca_alarm_definition.py
@@ -88,7 +88,7 @@ Valid fields for an Alarm Definition:
 Examle yaml file:
 
 notifications:
-  - name: Notify via HipChat
+  - name: Notify via Email
     type: email
     address: "root@localhost"
 
@@ -101,11 +101,11 @@ alarm_definitions:
       - "target_host"
       - "hostname"
     alarm_actions:
-      - Notify via HipChat
+      - Notify via Email
     ok_actions:
-      - Notify via HipChat
+      - Notify via Email
     undetermined_actions:
-      - Notify via HipChat
+      - Notify via Email
 
   - name: "Delete me"
     expression: "http_status > 0"

--- a/monasca-alarms/monasca_alarm_definition.py
+++ b/monasca-alarms/monasca_alarm_definition.py
@@ -1,0 +1,582 @@
+#!/usr/bin/python
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+from __future__ import print_function
+'''
+Loads Notifications and Alarm Definitions into Monasca. These are configured via a yaml file which contains two
+sections: notifications and alarm_definitions. Within the sections are the notifications and alarm definitions to be
+created, updated or deleted.
+
+For the possible arguments, see the argument parser definition.
+
+Valid fields for an Notification:
+    name:
+        required: true
+        description:
+            - The notification name
+    type:
+        required: true
+        description:
+            - The notification type
+    address:
+        required: true
+        description:
+            - The notification address, format varies with type
+    period:
+        required: true
+        description:
+            - The notification period, only valid for type WEBHOOK
+
+Valid fields for an Alarm Definition:
+    name:
+        required: true
+        description:
+            - The alarm definition name
+    description:
+        required: false
+        description:
+            - The alarm definition description text
+    expression:
+        required: true
+        description:
+            - The alarm definition expression
+    severity:
+        required: false
+        description:
+            - The alarm definition severity, one of LOW, MEDIUM, HIGH, CRITICAL
+    description:
+        required: false
+        description:
+            - The alarm definition description text
+    alarm_actions:
+        required: false
+        description:
+            -  Array of notification names that are invoked for the transition to the ALARM state
+    ok_actions:
+        required: false
+        description:
+            -  Array of notification names that are invoked for the transition to the OK state
+    severity:
+        required: false
+        default: "LOW"
+        description:
+            - The severity set for the alarm definition must be LOW, MEDIUM, HIGH or CRITICAL
+    state:
+        required: false
+        default: "present"
+        choices: [ present, absent ]
+        description:
+            - Whether the alarm definition should exist.  When absent, removes the alarm definition. The name
+              is used to determine the alarm definition to remove
+    undetermined_actions:
+        required: false
+        description:
+            -  Array of notification names that are invoked for the transition to the UNDETERMINED state
+Examle yaml file:
+
+notifications:
+  - name: Notify via HipChat
+    type: email
+    address: "root@localhost"
+
+alarm_definitions:
+  - name: "Host Status"
+    description: "Alarms when the specified host is down or not reachable"
+    severity: "HIGH"
+    expression: "host_alive_status > 0"
+    match_by:
+      - "target_host"
+      - "hostname"
+    alarm_actions:
+      - Notify via HipChat
+    ok_actions:
+      - Notify via HipChat
+    undetermined_actions:
+      - Notify via HipChat
+
+  - name: "Delete me"
+    expression: "http_status > 0"
+    match_by:
+      - "service"
+    state: absent
+
+  - name: "HTTP Status"
+    description: >
+      "Alarms when the specified HTTP endpoint is down or not reachable"
+    severity: "HIGH"
+    expression: "http_status > 0"
+    match_by:
+      - "service"
+      - "component"
+      - "hostname"
+      - "url"
+'''
+
+
+import argparse
+import os
+import sys
+import yaml
+
+try:
+    from monascaclient import client
+    from monascaclient import ksclient
+except ImportError:
+    paths = ["/opt/stack/service/monascaclient/venv", "/opt/monasca"]
+    for path in paths:
+        activate_this = os.path.realpath(path + '/bin/activate_this.py')
+        if not os.path.exists(activate_this):
+            continue
+        try:
+            execfile(activate_this, dict(__file__=activate_this))
+            from monascaclient import client
+            from monascaclient import ksclient
+        except ImportError:
+            monascaclient_found = False
+        else:
+            monascaclient_found = True
+            break
+else:
+    monascaclient_found = True
+
+class MonascaLoadDefinitions(object):
+    """ Loads Notifications and Alarm Definitions into Monasca
+    """
+    def __init__(self, args):
+        self._args = args
+        self._existing_notifications = None
+        self._existing_alarm_definitions = None
+        self._verbose = args['verbose']
+
+    def _keystone_auth(self):
+        """ Authenticate to Keystone and set self._token and self._api_url
+        """
+        if not self._args['keystone_token']:
+            try:
+                ks = ksclient.KSClient(**self._args)
+            except Exception, e:
+                raise Exception('Keystone KSClient Exception: %s' % e)
+
+            self._token = ks.token
+            if not self._args['monasca_api_url']:
+                self._api_url = ks.monasca_url
+            else:
+                self._api_url = self._args['monasca_api_url']
+        else:
+            if self._args['monasca_api_url'] is None:
+                raise Exception('Error: When specifying keystone_token, monasca_api_url is required')
+            self._token = self._args['keystone_token']
+            self._api_url = self._args['monasca_api_url']
+
+    def _get_existing_notifications(self):
+        if self._existing_notifications is None:
+            self._existing_notifications = self._monasca.notifications.list()
+        return self._existing_notifications
+
+    def _print_message(self, message):
+        if self._verbose:
+            print(message)
+
+    def run(self, data_file):
+        try:
+            with open(data_file) as f:
+                yaml_text = f.read()
+        except IOError:
+            raise Exception('Unable to open yaml alarm definitions: %s' % data_file)
+
+        yaml_data = yaml.safe_load(yaml_text)
+
+        self._keystone_auth()
+        self._monasca = client.Client(self._args['api_version'], self._api_url, token=self._token)
+        self._print_message('Using Monasca at {}'.format(self._api_url))
+        if 'notifications' not in yaml_data:
+            raise Exception('No notifications section in %s' % data_file)
+
+        (processed, changed, notification_ids) = self._do_notifications(yaml_data['notifications'])
+        self._print_message('%d Notifications Processed %d Notifications Changed' % (processed, changed))
+
+        if 'alarm_definitions' not in yaml_data:
+            raise Exception('No alarm_definitions section in %s' % data_file)
+
+        (processed, changed) = self.do_alarm_definitions(yaml_data['alarm_definitions'], notification_ids)
+        self._print_message('%d Alarm Definitions Processed %d Alarm Definitions Changed' % (processed, changed))
+
+
+    def _do_notifications(self, notifications):
+        processed = 0
+        changed = 0
+        notification_ids = {}
+        for notification in notifications:
+            processed += 1
+            if self._process_notification(notification, notification_ids):
+                changed += 1
+        return (processed, changed, notification_ids)
+
+    def _process_notification(self, notification, notification_ids):
+        name = notification['name']
+
+        self._print_message('Processing notification "{}"'.format(name))
+        # Get existing notifications
+        notifications = {notification['name']: notification for notification in self._get_existing_notifications()}
+
+        if notification.get('state', 'present') == 'absent':
+            if name not in notifications.keys():
+                self._print_message('Notification "{}" with state absent already does not exist'.format(name))
+                return False
+
+            self._print_message('Deleting notification "{}"'.format(name))
+
+            # TODO Delete could be tricky if this notification is used by alarm definitions
+            resp = self._monasca.notifications.delete(notification_id=notifications[name]['id'])
+            if resp.status_code == 204:
+                self._print_message('Successfully deleted notification "{}"'.format(name))
+                return True
+            else:
+                raise Exception(str(resp.status_code) + resp.text)
+        else:  # Only other option is state=present
+
+            def_kwargs = {'name': name, 'type': notification['type'].upper(), 'address': notification['address'],
+                          'period': notification.get('period', 0)}
+
+            if name in notifications.keys():
+                existing = notifications[name]
+                fields = ['type', 'address', 'period']
+                matches = True
+                for field in fields:
+                    if existing[field] != def_kwargs[field]:
+                        self._print_message('Notification "{}": Field {} value "{}" does not match expected "{}"'.format(
+                              name, field, existing[field], def_kwargs[field]))
+                        matches = False
+                if matches:
+                    self._print_message('Notification "{}" has no changes'.format(name))
+                    notification_ids[name] = existing['id']
+                    return False
+                def_kwargs['notification_id'] = notifications[name]['id']
+                self._print_message('Patching Notification "{}"'.format(name))
+                body = self._monasca.notifications.patch(**def_kwargs)
+            else:
+                self._print_message('Creating Notification "{}"'.format(name))
+                body = self._monasca.notifications.create(**def_kwargs)
+
+            if 'id' in body:
+                notification_ids[name] = body['id']
+                return True
+            else:
+                raise Exception(body)
+
+    def _get_existing_alarm_definitions(self):
+        if self._existing_alarm_definitions is None:
+            self._existing_alarm_definitions = self._monasca.alarm_definitions.list()
+        return self._existing_alarm_definitions
+
+    def do_alarm_definitions(self, definitions, notification_ids):
+        processed = 0
+        changed = 0
+        for definition in definitions:
+            processed += 1
+            if self._process_alarm_definition(definition, notification_ids):
+                changed += 1
+        return (processed, changed)
+
+    def _map_notifications(self, actions, notification_ids):
+        mapped = []
+        for action in actions:
+            if action not in notification_ids:
+                raise Exception("Unrecognized Notification {}".format(action))
+            mapped.append(notification_ids[action])
+        mapped.sort()
+        return mapped
+
+    def _process_alarm_definition(self, definition, notification_ids):
+        name = definition['name']
+        self._print_message('Processing Alarm Definition "{}"'.format(name))
+
+        expression = definition['expression']
+
+        # Get existing definitions
+        definitions = {definition['name']: definition for definition in self._get_existing_alarm_definitions()}
+
+        if definition.get('state', 'present') == 'absent':
+            if name not in definitions.keys():
+                self._print_message('Alarm Definition "{}" with state absent already does not exist'.format(name))
+                return False
+
+            resp = self._monasca.alarm_definitions.delete(alarm_id=definitions[name]['id'])
+            if resp.status_code == 204:
+                self._print_message('Successfully deleted Alarm Definition "{}"'.format(name))
+                return True
+            else:
+                raise Exception(str(resp.status_code) + resp.text)
+        else:  # Only other option is state=present
+            
+            alarm_actions = self._map_notifications(definition.get('alarm_actions', []), notification_ids)
+            ok_actions = self._map_notifications(definition.get('ok_actions', []), notification_ids)
+            undetermined_actions = self._map_notifications(definition.get('undetermined_actions', []), notification_ids)
+            def_kwargs = {'name': name, 'description': definition.get('description', ''), 'expression': expression,
+                          'match_by': definition.get('match_by', []), 'severity': definition.get('severity', 'LOW').upper(),
+                          'alarm_actions': alarm_actions,'ok_actions': ok_actions,
+                          'undetermined_actions': undetermined_actions}
+
+            if name in definitions.keys():
+                existing = definitions[name]
+                # Make sure the actions are in sorted order so the compare works.
+                existing['alarm_actions'].sort()
+                existing['ok_actions'].sort()
+                existing['undetermined_actions'].sort()
+                fields = ['name', 'description', 'expression', 'match_by', 'severity', 'alarm_actions', 'ok_actions', 'undetermined_actions']
+                matches = True
+                for field in fields:
+                    if existing[field] != def_kwargs[field]:
+                        self._print_message('Alarm Definition "{}": Field {} value "{}" does not match expected "{}"'.format(
+                              name, field, existing[field], def_kwargs[field]))
+                        matches = False
+                if matches:
+                    self._print_message('Alarm Definition "{}" has no changes'.format(name))
+                    return False
+                def_kwargs['alarm_id'] = definitions[name]['id']
+
+                self._print_message('Patching Alarm Definition "{}"'.format(name))
+                body = self._monasca.alarm_definitions.patch(**def_kwargs)
+            else:
+                self._print_message('Creating Alarm Definition "{}"'.format(name))
+                body = self._monasca.alarm_definitions.create(**def_kwargs)
+
+            if 'id' in body:
+                return True
+            else:
+                raise Exception(body)
+
+def _get_parser():
+    parser = argparse.ArgumentParser(
+        prog='monasca_alarm_definition',
+        #description=__doc__.strip(),
+        add_help=False,
+        # formatter_class=HelpFormatter,
+        formatter_class=lambda prog: argparse.HelpFormatter(
+            prog,
+            max_help_position=29)
+    )
+
+    # Global arguments
+    parser.add_argument('-h', '--help',
+                        action='store_true',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('-v', '--verbose',
+                        default=False, action="store_true",
+                        help="Print more verbose output.")
+
+    parser.add_argument('-k', '--insecure',
+                        default=False,
+                        action='store_true',
+                        help="Explicitly allow the client to perform "
+                        "\"insecure\" SSL (https) requests. The server's "
+                        "certificate will not be verified against any "
+                        "certificate authorities. "
+                        "This option should be used with caution.")
+
+    parser.add_argument('--cert-file',
+                        help='Path of certificate file to use in SSL '
+                        'connection. This file can optionally be '
+                        'prepended with the private key.')
+
+    parser.add_argument('--key-file',
+                        help='Path of client key to use in SSL connection. '
+                        'This option is not necessary if your key is'
+                        ' prepended to your cert file.')
+
+    parser.add_argument('--os-cacert',
+                        default=_env('OS_CACERT'),
+                        help='Specify a CA bundle file to use in verifying'
+                        ' a TLS (https) server certificate. Defaults to'
+                        ' env[OS_CACERT]. Without either of these, the'
+                        ' client looks for the default system CA'
+                        ' certificates.')
+
+    parser.add_argument('--timeout',
+                        default=600,
+                        help='Number of seconds to wait for a response.')
+
+    parser.add_argument('--os-username',
+                        default=_env('OS_USERNAME'),
+                        help='Defaults to env[OS_USERNAME].')
+
+    parser.add_argument('--os_username',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-password',
+                        default=_env('OS_PASSWORD'),
+                        help='Defaults to env[OS_PASSWORD].')
+
+    parser.add_argument('--os_password',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-project-id',
+                        default=_env('OS_PROJECT_ID'),
+                        help='Defaults to env[OS_PROJECT_ID].')
+
+    parser.add_argument('--os_project_id',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-project-name',
+                        default=_env('OS_PROJECT_NAME'),
+                        help='Defaults to env[OS_PROJECT_NAME].')
+
+    parser.add_argument('--os_project_name',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-domain-id',
+                        default=_env('OS_DOMAIN_ID'),
+                        help='Defaults to env[OS_DOMAIN_ID].')
+
+    parser.add_argument('--os_domain_id',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-domain-name',
+                        default=_env('OS_DOMAIN_NAME'),
+                        help='Defaults to env[OS_DOMAIN_NAME].')
+
+    parser.add_argument('--os_domain_name',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-auth-url',
+                        default=_env('OS_AUTH_URL'),
+                        help='Defaults to env[OS_AUTH_URL].')
+
+    parser.add_argument('--os_auth_url',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-region-name',
+                        default=_env('OS_REGION_NAME'),
+                        help='Defaults to env[OS_REGION_NAME].')
+
+    parser.add_argument('--os_region_name',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-auth-token',
+                        default=_env('OS_AUTH_TOKEN'),
+                        help='Defaults to env[OS_AUTH_TOKEN].')
+
+    parser.add_argument('--os_auth_token',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-no-client-auth',
+                        default=_env('OS_NO_CLIENT_AUTH'),
+                        action='store_true',
+                        help="Do not contact keystone for a token. "
+                             "Defaults to env[OS_NO_CLIENT_AUTH].")
+
+    parser.add_argument('--monasca-api-url',
+                        default=_env('MONASCA_API_URL'),
+                        help='Defaults to env[MONASCA_API_URL].')
+
+    parser.add_argument('--monasca_api_url',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--monasca-api-version',
+                        default=_env(
+                            'MONASCA_API_VERSION',
+                            default='2_0'),
+                        help='Defaults to env[MONASCA_API_VERSION] or 2_0')
+
+    parser.add_argument('--monasca_api_version',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-service-type',
+                        default=_env('OS_SERVICE_TYPE'),
+                        help='Defaults to env[OS_SERVICE_TYPE].')
+
+    parser.add_argument('--os_service_type',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--os-endpoint-type',
+                        default=_env('OS_ENDPOINT_TYPE'),
+                        help='Defaults to env[OS_ENDPOINT_TYPE].')
+
+    parser.add_argument('--os_endpoint_type',
+                        help=argparse.SUPPRESS)
+
+    parser.add_argument('--definitions-file',
+                        help='YAML file of Notifications and Alarm Definitions')
+
+    return parser
+
+def _env(*vars, **kwargs):
+    """Search for the first defined of possibly many env vars
+
+    Returns the first environment variable defined in vars, or
+    returns the default defined in kwargs.
+    """
+    for v in vars:
+        value = os.environ.get(v)
+        if value:
+            return value
+    return kwargs.get('default', '')
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
+    parser = _get_parser()
+    args = parser.parse_args(args)
+
+    if not args or args.help:
+        parser.print_help()
+        return
+
+    if not args.os_username and not args.os_auth_token:
+        raise Exception("You must provide a username via"
+                               " either --os-username or env[OS_USERNAME]"
+                               " or a token via --os-auth-token or"
+                               " env[OS_AUTH_TOKEN]")
+
+    if not args.os_password and not args.os_auth_token:
+        raise Exception("You must provide a password via"
+                               " either --os-password or env[OS_PASSWORD]"
+                               " or a token via --os-auth-token or"
+                               " env[OS_AUTH_TOKEN]")
+
+    kwargs = {
+        'username': args.os_username,
+        'password': args.os_password,
+        'keystone_token': args.os_auth_token,
+        'auth_url': args.os_auth_url,
+        'service_type': args.os_service_type,
+        'endpoint_type': args.os_endpoint_type,
+        'os_cacert': args.os_cacert,
+        'project_id': args.os_project_id,
+        'project_name': args.os_project_name,
+        'domain_id': args.os_domain_id,
+        'domain_name': args.os_domain_name,
+        'insecure': args.insecure,
+        'monasca_api_url': args.monasca_api_url,
+        'api_version': args.monasca_api_version,
+        'verbose': args.verbose
+    }
+
+    if not monascaclient_found:
+        print("python-monascaclient >= 1.0.9 is required", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.definitions_file:
+        raise Exception('--definitions-file argument is required')
+
+    definition = MonascaLoadDefinitions(kwargs)
+
+    definition.run(args.definitions_file)
+
+if __name__ == "__main__":
+    main()

--- a/monasca-alarms/start.sh
+++ b/monasca-alarms/start.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+
+MONASCA_API_WAIT_RETRIES=${MONASCA_API_WAIT_RETRIES:-"24"}
+MONASCA_API_WAIT_DELAY=${MONASCA_API_WAIT_DELAY:-"5"}
+
+if [ -n "$MONASCA_WAIT_FOR_API" ]; then
+  echo "Waiting for Monasca API to become available..."
+  success="false"
+
+  for i in $(seq $MONASCA_API_WAIT_RETRIES); do
+    monasca alarm-definition-list --limit 1
+    if [ $? -eq 0 ]; then
+      success="true"
+      break
+    else
+      echo "Monasca API not yet ready (attempt $i of $MONASCA_API_WAIT_RETRIES)"
+      sleep "$MONASCA_API_WAIT_DELAY"
+    fi
+  done
+fi
+
+if [ "$success" != "true" ]; then
+  echo "Monasca API failed to become ready, exiting..."
+  sleep 1
+  exit 1
+fi
+
+echo "Loading Definitions...."
+python monasca_alarm_definition.py --verbose --definitions-file /config/definitions.yml 


### PR DESCRIPTION
Container runs once to create Notifications and Alarm Definitions
in Monasca. The creation command checks first if the Notification
or Alarm Definition exists and matches what is expected. If it
matches, nothing is done so this container is idempotent.