### PR TITLE
Add jinja2 templating to monasca-alarms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - influxdb
 
   alarms:
-    image: monasca/alarms:latest
+    image: monasca/alarms:1.1.0
 
   zookeeper:
     image: zookeeper:3.3

--- a/monasca-alarms/Dockerfile
+++ b/monasca-alarms/Dockerfile
@@ -13,13 +13,13 @@ ENV MONASCA_WAIT_FOR_API=true \
   OS_USER_DOMAIN_NAME=Default
 
 RUN apk add --no-cache \
-    python py2-pip py2-netaddr py2-yaml && \
+    python py2-pip py2-netaddr py2-yaml py2-jinja2 && \
   apk add --no-cache --virtual build-dep \
     git python-dev make g++ linux-headers && \
   pip install python-monascaclient && \
   rm -rf /root/.cache/pip && \
   apk del build-dep
 
-COPY definitions.yml /config/definitions.yml
-COPY monasca_alarm_definition.py start.sh /
+COPY definitions.yml.j2 /config/definitions.yml.j2
+COPY monasca_alarm_definition.py template.py start.sh /
 CMD ["/start.sh"]

--- a/monasca-alarms/build.yml
+++ b/monasca-alarms/build.yml
@@ -1,5 +1,5 @@
 repository: monasca/alarms
 variants:
-  - tag: 1.0.0
+  - tag: 1.1.0
     aliases:
       - :latest

--- a/monasca-alarms/definitions.yml.j2
+++ b/monasca-alarms/definitions.yml.j2
@@ -18,9 +18,9 @@
 # Default Notifications and Alarms
 #
 notifications:
-  - name: root email
-    type: email
-    address: root@localhost
+  - name: default
+    type: "{{ NOTIFICATION_TYPE | default('email') }}"
+    address: "{{ NOTIFICATION_ADDRESS | default('root@localhost') }}"
 
 alarm_definitions:
   - name: "Host Status"
@@ -31,11 +31,11 @@ alarm_definitions:
       - "target_host"
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "HTTP Status"
     description: >
       "Alarms when the specified HTTP endpoint is down or not reachable"
@@ -47,33 +47,33 @@ alarm_definitions:
       - "hostname"
       - "url"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "CPU Usage"
     description: "Alarms when CPU usage is high"
     expression: "avg(cpu.idle_perc) < 10 times 3"
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "High CPU IOWait"
     description: "Alarms when CPU IOWait is high, possible slow disk issue"
     expression: "avg(cpu.wait_perc) > 40 times 3"
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Disk Inode Usage"
     description: "Alarms when disk inode usage is high"
     expression: "disk.inode_used_perc > 90"
@@ -82,11 +82,11 @@ alarm_definitions:
       - "device"
     severity: "HIGH"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Disk Usage"
     description: "Alarms when disk usage is high"
     expression: "disk.space_used_perc > 90"
@@ -95,32 +95,32 @@ alarm_definitions:
       - "device"
     severity: "HIGH"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Memory Usage"
     description: "Alarms when memory usage is high"
     severity: "HIGH"
     expression: "avg(mem.usable_perc) < 10 times 3"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Network Errors"
     description: >
       "Alarms when either incoming or outgoing network errors are high"
     severity: "MEDIUM"
     expression: "net.in_errors_sec > 5 or net.out_errors_sec > 5"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Process Check"
     description: "Alarms when the specified process is not running"
     severity: "HIGH"
@@ -129,11 +129,11 @@ alarm_definitions:
       - "process_name"
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Crash Dump Count"
     description: "Alarms when a crash directory is found"
     severity: "MEDIUM"
@@ -141,11 +141,11 @@ alarm_definitions:
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "Monasca Agent Collection Time"
     description: "Alarms when the elapsed time the Monasca Agent takes to \
                     collect metrics is high"
@@ -153,41 +153,41 @@ alarm_definitions:
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "ZooKeeper Latency"
     description: "Alarms when the ZooKeeper latency is high"
     expression: "avg(zookeeper.avg_latency_sec) > 1 times 3"
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "NTP Time Sync"
     description: "Alarms when the NTP time offset is high"
     expression: "ntp.offset > 5 or ntp.offset < -5"
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default
   - name: "NTP Connection Status"
     description: "Alarms when the connection failed to the NTP server"
     expression: "ntp.connection_status > 0"
     match_by:
       - "hostname"
     alarm_actions:
-      - root email
+      - default
     ok_actions:
-      - root email
+      - default
     undetermined_actions:
-      - root email
+      - default

--- a/monasca-alarms/start.sh
+++ b/monasca-alarms/start.sh
@@ -27,4 +27,6 @@ if [ "$success" != "true" ]; then
 fi
 
 echo "Loading Definitions...."
+
+python /template.py /config/definitions.yml.j2 /config/definitions.yml
 python monasca_alarm_definition.py --verbose --definitions-file /config/definitions.yml 

--- a/monasca-alarms/template.py
+++ b/monasca-alarms/template.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import print_function
+
+import os
+import sys
+
+from jinja2 import Template
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('Usage: {} [input] [output]'.format(sys.argv[0]))
+        sys.exit(1)
+
+    in_path = sys.argv[1]
+    out_path = sys.argv[2]
+
+    with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
+        t = Template(in_file.read(),
+                     keep_trailing_newline=True,
+                     lstrip_blocks=True,
+                     trim_blocks=True)
+        out_file.write(t.render(os.environ))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This makes the default notification method type and address
configurable at runtime.