### PR TITLE
Support forcing a push for an unchanged build.yml via commit message

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -209,6 +209,7 @@ def main():
     print('TRAVIS_PULL_REQUEST_BRANCH=',
           os.environ.get('TRAVIS_PULL_REQUEST_BRANCH'))
     print('TRAVIS_TAG=', os.environ.get('TRAVIS_TAG'))
+    print('TRAVIS_COMMIT_MESSAGE=', os.environ.get('TRAVIS_COMMIT_MESSAGE'))
 
     files = get_changed_files()
     modules = get_dirty_modules(files)


### PR DESCRIPTION
Currently `ci.py` won't try to push unless build.yml is changed. This works alright for most standard semver images, but it makes `master-{date}-{time}`-style image tags incompatible with our CI.

This adds support for building using a flag in the commit message, `!push`. When `!push module` is included in a merge commit message (on its own line), `ci.py` will build and push the image regardless of whether or not the `build.yml` has changed.