### PR TITLE
Add print of thresh config file

### DIFF
--- a/monasca-thresh/submit.sh
+++ b/monasca-thresh/submit.sh
@@ -36,6 +36,8 @@ if [ "$found" = "true" ]; then
   echo "Storm topology already exists, will not submit again"
   # TODO handle upgrades
 else
+  echo "Using Thresh Config file /storm/conf/thresh-config.yml. Contents:"
+  cat /storm/conf/thresh-config.yml | grep -vi password
   echo "Submitting storm topology..."
   storm jar /monasca-thresh.jar \
     monasca.thresh.ThresholdingEngine \


### PR DESCRIPTION
Also, forces a new build of the thresh container to pick up the
new storm container which has additional configuration env
vars

!push monasca-thresh