### PR TITLE
Monasca API did not handle non ascii characters

### DIFF
--- a/monasca-api-python/start.sh
+++ b/monasca-api-python/start.sh
@@ -75,6 +75,8 @@ else
   cp /etc/monasca/api-logging.conf.j2 /etc/monasca/api-logging.conf
 fi
 
+# Needed to allow utf8 use in the Monasca API
+export PYTHONIOENCODING=utf-8
 gunicorn --capture-output \
   -n monasca-api \
   --worker-class="$GUNICORN_WORKER_CLASS" \


### PR DESCRIPTION
Added setting of PYTHON_ENCODING. Seems like it would not be needed
but testing shows it is