### PR TITLE
Increase docker-compose version up to 3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   influxdb:
     image: influxdb:latest


### PR DESCRIPTION
docker-compose in 3rd version offers compatybility with docker's
swarm mode. Since docker-compose in current shape works for
3rd version, the change is painless and allows to deploy monasca
over swarm with Docker (at least) 1.13 as in:

```docker deploy --compose-file docker-compose.yml mon```