### PR TITLE
Add API access log

### DIFF
--- a/monasca-api-python/Dockerfile
+++ b/monasca-api-python/Dockerfile
@@ -10,6 +10,7 @@ ARG REBUILD=1
 ENV CONFIG_TEMPLATE=true \
   LOG_LEVEL_ROOT=WARN \
   LOG_LEVEL_CONSOLE=INFO \
+  LOG_LEVEL_ACCESS=INFO \
   API_PORT=8070 \
   KAFKA_URI=kafka:9092 \
   KAFKA_WAIT_FOR_TOPICS=alarm-state-transitions,metrics \
@@ -27,7 +28,9 @@ ENV CONFIG_TEMPLATE=true \
   KEYSTONE_ADMIN_USER=admin \
   KEYSTONE_ADMIN_PASSWORD=secretadmin \
   KEYSTONE_ADMIN_TENANT=admin \
-  KEYSTONE_ADMIN_DOMAIN=default
+  KEYSTONE_ADMIN_DOMAIN=default \
+  ACCESS_LOG_FORMAT="%(asctime)s [%(process)d] gunicorn.access [%(levelname)s] %(message)s" \
+  ACCESS_LOG_FIELDS='%(h)s %(l)s %(u)s %(t)s %(r)s %(s)s %(b)s "%(f)s" "%(a)s" %(L)s'
 
 RUN apk add --no-cache python py2-pip py2-jinja2 curl mysql-client && \
   apk add --no-cache --virtual build-dep \

--- a/monasca-api-python/README.md
+++ b/monasca-api-python/README.md
@@ -68,6 +68,7 @@ A number of environment variables can be passed to the container:
 |---------------------------|---------------|----------------------------------|
 | `LOG_LEVEL_ROOT`          | `WARN`        | The level of the root logger     |
 | `LOG_LEVEL_CONSOLE`       | `INFO`        | Minimum level for console output |
+| `LOG_LEVEL_ACCESS`        | `INFO`        | Minimum level for access output  |
 | `API_PORT`                | `8070`        | The API's HTTP port              |
 | `KAFKA_URI`               | `kafka:9092`  | The host and port for kafka      |
 | `KAFKA_WAIT_FOR_TOPICS`   | `alarm-state-transitions,metrics` | Topics to wait on at startup |
@@ -97,6 +98,8 @@ A number of environment variables can be passed to the container:
 | `AGENT_AUTHORIZED_ROLES`     | `monasca-agent` | Roles for metric write only users |
 | `READ_ONLY_AUTHORIZED_ROLES` | `monasca-read-only-user` | Roles for read only users    |
 | `DELEGATE_AUTHORIZED_ROLES`  | `admin`       | Roles allow to read/write cross tenant ID |
+| `ACCESS_LOG_FORMAT`  | `%(asctime)s [%(process)d] gunicorn.access [%(levelname)s] %(message)s` | Log format for access log |
+| `ACCESS_LOG_FIELDS`  | `%(h)s %(l)s %(u)s %(t)s %(r)s %(s)s %(b)s "%(f)s" "%(a)s" %(L)s` | Access log fields |
 
 If additional values need to be overridden, new config files or jinja2 templates
 can be provided by mounting a replacement on top of the original template:

--- a/monasca-api-python/api-config.conf.j2
+++ b/monasca-api-python/api-config.conf.j2
@@ -108,15 +108,19 @@ password = {{ INFLUX_PASSWORD }}
 database_name = {{ INFLUX_DB }}
 
 [database]
-url = "mysql+pymysql://{{ MYSQL_USER }}:{{ MYSQL_PASSWORD }}@{{ MYSQL_HOST }}/{{ MYSQL_DB }}"
+connection = "mysql+pymysql://{{ MYSQL_USER }}:{{ MYSQL_PASSWORD }}@{{ MYSQL_HOST }}/{{ MYSQL_DB }}"
 
 [keystone_authtoken]
-identity_uri = {{ KEYSTONE_IDENTITY_URI }}
+auth_type = password
+auth_url = {{ KEYSTONE_IDENTITY_URI }}
 auth_uri = {{ KEYSTONE_AUTH_URI }}
-admin_password = {{ KEYSTONE_ADMIN_PASSWORD }}
-admin_user = {{ KEYSTONE_ADMIN_USER }}
-admin_tenant_name = {{ KEYSTONE_ADMIN_TENANT }}
+username = {{ KEYSTONE_ADMIN_USER }}
+password = {{ KEYSTONE_ADMIN_PASSWORD }}
+user_domain_name = Default
+project_name = {{ KEYSTONE_ADMIN_TENANT }}
+project_domain_name = Default
+service_token_roles_required = true
+insecure = false
 cafile =
 certfile =
 keyfile =
-insecure = false

--- a/monasca-api-python/api-logging.conf.j2
+++ b/monasca-api-python/api-logging.conf.j2
@@ -1,15 +1,24 @@
+[default]
+disable_existing_loggers = 0
+
 [loggers]
-keys = root, sqlalchemy, kafka
+keys = root, gunicorn.access, sqlalchemy, kafka
 
 [handlers]
-keys = console
+keys = console, console_access
 
 [formatters]
-keys = context
+keys = context, generic
 
 [logger_root]
 level = {{ LOG_LEVEL_ROOT }}
 handlers = console
+
+[logger_gunicorn.access]
+level = INFO
+handlers = console_access
+propagate = 0
+qualname = gunicorn.access
 
 [logger_sqlalchemy]
 qualname = sqlalchemy.engine
@@ -32,5 +41,16 @@ args = (sys.stderr,)
 level = {{ LOG_LEVEL_CONSOLE }}
 formatter = context
 
+[handler_console_access]
+class = logging.StreamHandler
+args = (sys.stderr,)
+level = {{ LOG_LEVEL_ACCESS }}
+formatter = generic
+
 [formatter_context]
 class = oslo_log.formatters.ContextFormatter
+
+[formatter_generic]
+format={{ ACCESS_LOG_FORMAT }}
+datefmt=%Y-%m-%d %H:%M:%S
+class=logging.Formatter

--- a/monasca-api-python/start.sh
+++ b/monasca-api-python/start.sh
@@ -80,5 +80,7 @@ gunicorn --capture-output \
   --worker-class="$GUNICORN_WORKER_CLASS" \
   --worker-connections="$GUNICORN_WORKER_CONNECTIONS" \
   --backlog=$GUNICORN_BACKLOG \
+  --access-logfile - \
+  --access-logformat "$ACCESS_LOG_FIELDS" \
   --paste /etc/monasca/api-config.ini \
   -w "$GUNICORN_WORKERS"


### PR DESCRIPTION
It goes to stderr with other logging. It is marked by having
gunicorn.access in the line.

In addition, modify the config file to remove deprecation
warnings.