### PR TITLE
Add healthchecks to conf file

### DIFF
--- a/monasca-api-python/api-config.conf.j2
+++ b/monasca-api-python/api-config.conf.j2
@@ -20,6 +20,7 @@ notification_methods = monasca_api.v2.reference.notifications:Notifications
 dimension_values = monasca_api.v2.reference.metrics:DimensionValues
 dimension_names = monasca_api.v2.reference.metrics:DimensionNames
 notification_method_types = monasca_api.v2.reference.notificationstype:NotificationsType
+healthchecks = monasca_api.healthchecks:HealthChecks
 
 [security]
 # The roles that are allowed full access to the API.


### PR DESCRIPTION
This allows us to support newer versions of the API. Otherwise,
it fails with:
AttributeError: 'NoneType' object has no attribute 'rpartition'