### PR TITLE
Upgrade docker to enable multi-stage builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,13 @@ env:
   - IGNORE_DOCKER_VERSION=true
 
 before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y install docker-ce
+  - pip install pip --upgrade
   - pip install git+https://github.com/timothyb89/dbuild.git
 
 script:
+  - docker --version
   - python ci.py


### PR DESCRIPTION
Instead of relying on the docker engine provided
by Travis, let's install latest available
version from official Docker Repository.

Closes #80