### PR TITLE
Allow Thresh to run without storm

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -28,12 +28,11 @@ import yaml
 TAG_REGEX = re.compile(r'^!(\w+)(?:\s+([\w-]+))?$')
 
 MODULE_TO_COMPOSE_SERVICE = {
-    'storm': 'storm-supervisor,storm-nimbus',
     'monasca-agent-forwarder': 'agent-forwarder',
     'zookeeper': 'zookeeper',
     'influxdb': 'influxdb',
     'kafka': 'kafka',
-    'monasca-thresh': 'thresh-init',
+    'monasca-thresh': 'thresh',
     'monasca-persister-python': 'monasca-persister',
     'mysql-init': 'mysql-init',
     'monasca-api-python': 'monasca',
@@ -335,10 +334,8 @@ def get_docker_id(init_job):
 
 def wait_for_init_jobs():
     init_status_dict = {"mysql-init": False,
-                        "thresh-init": False,
                         "influxdb-init": False}
     docker_id_dict = {"mysql-init": "",
-                      "thresh-init": "",
                       "influxdb-init": ""}
     amount_succeeded = 0
     for attempt in range(40):
@@ -360,8 +357,8 @@ def wait_for_init_jobs():
         else:
             print("Not all init jobs have succeeded. Attempt: " + str(attempt + 1) + " of 40")
 
-    if amount_succeeded != 3:
-        print("Init-jobs did not succeed printing docker ps and logs")
+    if amount_succeeded != len(docker_id_dict):
+        print("Init-jobs did not succeed, printing docker ps and logs")
         output_docker_ps()
         output_docker_logs()
         print('Exiting!')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,32 +111,14 @@ services:
       - zookeeper
       - kafka
 
-  storm-nimbus:
-    image: monasca/storm:1.0.3
-    command: storm nimbus
+  thresh:
+    image: monasca/thresh:latest
     environment:
-      STORM_LOCAL_HOSTNAME: "storm-nimbus"
-      WORKER_LOGS_TO_STDOUT: "true"
+      NO_STORM_CLUSTER: "true"
+      WORKER_MAX_HEAP_MB: "256"
     depends_on:
       - zookeeper
       - kafka
-
-  storm-supervisor:
-    image: monasca/storm:1.0.3
-    command: storm supervisor
-    depends_on:
-      - storm-nimbus
-      - zookeeper
-      - kafka
-
-  thresh-init:
-    image: monasca/thresh:master
-    environment:
-      STORM_WAIT_RETRIES: 50
-    depends_on:
-      - zookeeper
-      - storm-nimbus
-      - storm-supervisor
 
   monasca-notification:
     image: monasca/notification:master

--- a/monasca-thresh/Dockerfile
+++ b/monasca-thresh/Dockerfile
@@ -12,6 +12,7 @@ ENV COMMON_REPO=https://git.openstack.org/openstack/monasca-common.git \
   STORM_WAIT_DELAY=5 \
   STORM_WAIT_TIMEOUT=20 \
   KAFKA_URI="kafka:9092" \
+  KAFKA_WAIT_FOR_TOPICS=alarm-state-transitions,metrics,events \
   MYSQL_DB_HOST=mysql \
   MYSQL_DB_PORT=3306 \
   MYSQL_DB_USERNAME=thresh \
@@ -22,8 +23,10 @@ ARG REBUILD=1
 ARG SKIP_COMMON_TESTS=false
 ARG SKIP_THRESH_TESTS=false
 
-RUN apk add --no-cache --virtual build-dep maven git openjdk8 && \
+RUN apk add --no-cache --virtual build-dep maven git py2-pip python-dev git openjdk8 make g++ && \
+  apk add --no-cache python mysql-client && \
   mkdir /root/.m2 && \
+  pip install pykafka && \
   python /template.py settings.xml.j2 /root/.m2/settings.xml && \
   mkdir /repo && \
   set -x && mkdir /monasca-common && cd /monasca-common && \
@@ -47,6 +50,6 @@ RUN apk add --no-cache --virtual build-dep maven git openjdk8 && \
   rm -rf /repo && \
   apk del build-dep
 
-COPY submit.sh /
+COPY kafka_wait_for_topics.py submit.sh /
 
 CMD ["/submit.sh"]

--- a/monasca-thresh/README.md
+++ b/monasca-thresh/README.md
@@ -38,24 +38,38 @@ to no configuration and can be minimally run like so:
 Configuration
 -------------
 
-| Variable             | Default        | Description                              |
-|----------------------|----------------|------------------------------------------|
-| `MYSQL_DB_HOST`      | `mysql`        | MySQL hostname                           |
-| `MYSQL_DB_PORT`      | `3306`         | MySQL port                               |
-| `MYSQL_DB_USERNAME`  | `thresh`       | MySQL username                           |
-| `MYSQL_DB_PASSWORD`  | `password`     | MySQL password                           |
-| `MYSQL_DB_DATABASE`  | `mon`          | MySQL database name                      |
-| `MYSQL_WAIT_RETRIES` | `24`           | # of tries to verify MySQL availability  |
-| `MYSQL_WAIT_DELAY`   | `5`            | # seconds between retry attempts         |
-| `KAFKA_URI`          | `kafka:9092`   | If `true`, disable remote root login     |
-| `KAFKA_WAIT_FOR_TOPICS` | `alarm-state-transitions,metrics,events`    | Comma-separated list of topic names to check |
-| `KAFKA_WAIT_RETRIES` | `24`           | # of tries to verify Kafka availability  |
-| `KAFKA_WAIT_DELAY`   | `5`            | # seconds between retry attempts         |
-| `ZOOKEEPER_URL`      | `zookeeper:2181` | Zookeeper URL                          |
-| `NO_STORM_CLUSTER`   | unset          | If `true`, run without Storm daemons     |
-| `WORKER_MAX_HEAP_MB` | unset          | If set and `NO_STORM_CLUSTER` is `true`, use as Heap Size for JVM |
-| `STORM_WAIT_RETRIES` | `24`           | # of tries to verify Storm availability  |
-| `STORM_WAIT_DELAY`   | `5`            | # seconds between retry attempts         |
+| Variable                      | Default        | Description                              |
+|-------------------------------|----------------|------------------------------------------|
+| `MYSQL_DB_HOST`               | `mysql`        | MySQL hostname                           |
+| `MYSQL_DB_PORT`               | `3306`         | MySQL port                               |
+| `MYSQL_DB_USERNAME`           | `thresh`       | MySQL username                           |
+| `MYSQL_DB_PASSWORD`           | `password`     | MySQL password                           |
+| `MYSQL_DB_DATABASE`           | `mon`          | MySQL database name                      |
+| `MYSQL_WAIT_RETRIES`          | `24`           | # of tries to verify MySQL availability  |
+| `MYSQL_WAIT_DELAY`            | `5`            | # seconds between retry attempts         |
+| `KAFKA_URI`                   | `kafka:9092`   | If `true`, disable remote root login     |
+| `KAFKA_WAIT_FOR_TOPICS`       | `alarm-state-transitions,metrics,events`    | Comma-separated list of topic names to check |
+| `KAFKA_WAIT_RETRIES`          | `24`           | # of tries to verify Kafka availability  |
+| `KAFKA_WAIT_DELAY`            | `5`            | # seconds between retry attempts         |
+| `ZOOKEEPER_URL`               | `zookeeper:2181` | Zookeeper URL                          |
+| `NO_STORM_CLUSTER`            | unset          | If `true`, run without Storm daemons     |
+| `STORM_WAIT_RETRIES`          | `24`           | # of tries to verify Storm availability  |
+| `STORM_WAIT_DELAY`            | `5`            | # seconds between retry attempts         |
+| `WORKER_MAX_HEAP_MB`          | unset          | If set and `NO_STORM_CLUSTER` is `true`, use as Heap Size for JVM |
+| `METRIC_SPOUT_THREADS`        | `2`            | Metric Spout threads        |
+| `METRIC_SPOUT_TASKS`          | `2`            | Metric Spout tasks          |
+| `EVENT_SPOUT_THREADS`         | `2`            | Event Spout Threads         |
+| `EVENT_SPOUT_TASKS`           | `2`            | Event Spout Tasks           |
+| `EVENT_BOLT_THREADS`          | `2`            | Event Bolt Threads          |
+| `EVENT_BOLT_TASKS`            | `2`            | Event Bolt Tasks            |
+| `FILTERING_BOLT_THREADS`      | `2`            | Filtering Bolt Threads      |
+| `FILTERING_BOLT_TASKS`        | `2`            | Filtering Bolt Tasks        |
+| `ALARM_CREATION_BOLT_THREADS` | `2`            | Alarm Creation Bolt Threads |
+| `ALARM_CREATION_BOLT_TASKS`   | `2`            | Alarm Creation Bolt Tasks   |
+| `AGGREGATION_BOLT_THREADS`    | `2`            | Aggregation Bolt Threads    |
+| `AGGREGATION_BOLT_TASKS`      | `2`            | Aggregation Bolt Tasks      |
+| `THRESHOLDING_BOLT_THREADS`   | `2`            | Thresholding Bolt Threads   |
+| `THRESHOLDING_BOLT_TASKS`     | `2`            | Thresholding Bolt Tasks     |
 
 Running with and without Storm
 ------------------------------

--- a/monasca-thresh/README.md
+++ b/monasca-thresh/README.md
@@ -1,0 +1,105 @@
+monasca-thresh Dockerfile
+===============================
+
+This image has a containerized version of the Monasca Threshold Engine. For
+more information on the Monasca project, see [the wiki][1].
+
+Sources: [monasca-thresh][2] &middot; [monasca-docker][3] &middot; [Dockerfile][4]
+
+Tags
+----
+
+Images in this repository are tagged as follows:
+
+ * `latest`: refers to the latest stable point release, e.g. `1.7.0`
+ * `1.0.0`, `1.0`, `1`: standard semver tags based on git tags in the
+   [official repository][2].
+ * `newton`, `ocata`, etc: named versions following OpenStack release names
+   built from the tip of `stable/RELEASENAME` branches in the repository
+ * `master`, `master-DATESTAMP`: unstable testing builds from the master branch,
+   these may have features or enhancements not available in stable releases, but
+   are not production-ready.
+
+Note that features in this Dockerfile, particularly relating to running in
+Docker and Kubernetes environments, require code that has not yet been made
+available in a tagged release. Until this changes, only `master` images may be
+available and `latest` may point to `master` images.
+
+Usage
+-----
+
+The Threshold engine requires configured instances of MySQL, Kafka,
+Zookeeper, and optionally Storm [monasca-api][5]. In environments resembling the official
+[docker-compose][3] or [Kubernetes][6] environments, this image requires little
+to no configuration and can be minimally run like so:
+
+    docker run monasca/thresh:latest
+
+Configuration
+-------------
+
+| Variable             | Default        | Description                              |
+|----------------------|----------------|------------------------------------------|
+| `MYSQL_DB_HOST`      | `mysql`        | MySQL hostname                           |
+| `MYSQL_DB_PORT`      | `3306`         | MySQL port                               |
+| `MYSQL_DB_USERNAME`  | `thresh`       | MySQL username                           |
+| `MYSQL_DB_PASSWORD`  | `password`     | MySQL password                           |
+| `MYSQL_DB_DATABASE`  | `mon`          | MySQL database name                      |
+| `MYSQL_WAIT_RETRIES` | `24`           | # of tries to verify MySQL availability  |
+| `MYSQL_WAIT_DELAY`   | `5`            | # seconds between retry attempts         |
+| `KAFKA_URI`          | `kafka:9092`   | If `true`, disable remote root login     |
+| `KAFKA_WAIT_FOR_TOPICS` | `alarm-state-transitions,metrics,events`    | Comma-separated list of topic names to check |
+| `KAFKA_WAIT_RETRIES` | `24`           | # of tries to verify Kafka availability  |
+| `KAFKA_WAIT_DELAY`   | `5`            | # seconds between retry attempts         |
+| `ZOOKEEPER_URL`      | `zookeeper:2181` | Zookeeper URL                          |
+| `NO_STORM_CLUSTER`   | unset          | If `true`, run without Storm daemons     |
+| `WORKER_MAX_HEAP_MB` | unset          | If set and `NO_STORM_CLUSTER` is `true`, use as Heap Size for JVM |
+| `STORM_WAIT_RETRIES` | `24`           | # of tries to verify Storm availability  |
+| `STORM_WAIT_DELAY`   | `5`            | # seconds between retry attempts         |
+
+Running with and without Storm
+------------------------------
+
+The Threshold Engine can be run in two different modes, with Storm Daemons or without Storm Daemons.
+If run with the Storm Daemons, multiple Storm Supervisor containers can be used with more than one worker process
+in each. With no Storm Daemons, only a single Threshold Engine container can be run with a single worker process.
+
+The default docker-compose.yml file is configured to run without Storm. To change docker-compose.yml to run
+with Storm, delete the `thresh` service entry and replace it with the below:
+
+```
+  storm-nimbus:
+    image: monasca/storm:1.0.3
+    command: storm nimbus
+    environment:
+      STORM_LOCAL_HOSTNAME: "storm-nimbus"
+      WORKER_LOGS_TO_STDOUT: "true"
+    depends_on:
+      - zookeeper
+      - kafka
+
+  storm-supervisor:
+    image: monasca/storm:1.0.3
+    command: storm supervisor
+    depends_on:
+      - storm-nimbus
+      - zookeeper
+      - kafka
+
+  thresh-init:
+    image: monasca/thresh:master
+    environment:
+      STORM_WAIT_RETRIES: 50
+    depends_on:
+      - zookeeper
+      - storm-nimbus
+      - storm-supervisor
+```
+
+[1]: https://wiki.openstack.org/wiki/Monasca
+[2]: https://github.com/openstack/monasca-thresh/
+[3]: https://github.com/hpcloud-mon/monasca-docker/
+[4]: https://github.com/hpcloud-mon/monasca-docker/blob/master/monasca-thresh/Dockerfile
+[5]: https://github.com/hpcloud-mon/monasca-docker/blob/master/storm/Dockerfile
+[6]: https://github.com/hpcloud-mon/monasca-docker/blob/master/k8s/
+[7]: https://v2.developer.pagerduty.com/docs/events-api

--- a/monasca-thresh/kafka_wait_for_topics.py
+++ b/monasca-thresh/kafka_wait_for_topics.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function
+
+import os
+import sys
+
+from pykafka import KafkaClient
+
+client = KafkaClient(hosts=os.environ.get('KAFKA_URI', 'kafka:9092'))
+
+required_topics = os.environ.get('KAFKA_WAIT_FOR_TOPICS', '').split(',')
+print('Checking for available topics:', repr(required_topics))
+for req_topic in required_topics:
+    if req_topic in client.topics:
+        topic = client.topics[req_topic]
+        if len(topic.partitions) > 0:
+            print('Topic is ready:', req_topic)
+        else:
+            print('Topic has no partitions:', req_topic)
+            sys.exit(1)
+    else:
+        print('Topic not found:', req_topic)
+        sys.exit(1)

--- a/monasca-thresh/submit.sh
+++ b/monasca-thresh/submit.sh
@@ -2,6 +2,68 @@
 
 TOPOLOGY_NAME="thresh-cluster"
 
+MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-"24"}
+MYSQL_WAIT_DELAY=${MYSQL_WAIT_DELAY:-"5"}
+
+KAFKA_WAIT_RETRIES=${KAFKA_WAIT_RETRIES:-"24"}
+KAFKA_WAIT_DELAY=${KAFKA_WAIT_DELAY:-"5"}
+
+echo "Waiting for MySQL to become available..."
+success="false"
+for i in $(seq $MYSQL_WAIT_RETRIES); do
+  mysqladmin status \
+      --host="$MYSQL_DB_HOST" \
+      --port="$MYSQL_DB_PORT" \
+      --user="$MYSQL_DB_USERNAME" \
+      --password="$MYSQL_DB_PASSWORD" \
+      --connect_timeout=10
+  if [ $? -eq 0 ]; then
+    echo "MySQL is available, continuing..."
+    success="true"
+    break
+  else
+    echo "Connection attempt $i of $MYSQL_WAIT_RETRIES failed"
+    sleep "$MYSQL_WAIT_DELAY"
+  fi
+done
+
+if [ "$success" != "true" ]; then
+    echo "Unable to reach MySQL database! Exiting..."
+    sleep 1
+    exit 1
+fi
+
+if [ -n "$KAFKA_WAIT_FOR_TOPICS" ]; then
+  echo "Waiting for Kafka topics to become available..."
+  success="false"
+
+  for i in $(seq $KAFKA_WAIT_RETRIES); do
+    python /kafka_wait_for_topics.py
+    if [ $? -eq 0 ]; then
+      success="true"
+      break
+    else
+      echo "Kafka not yet ready (attempt $i of $KAFKA_WAIT_RETRIES)"
+      sleep "$KAFKA_WAIT_DELAY"
+    fi
+  done
+
+  if [ "$success" != "true" ]; then
+    echo "Kafka failed to become ready, exiting..."
+    sleep 1
+    exit 1
+  fi
+fi
+
+if ${NO_STORM_CLUSTER} = "true"; then
+  echo "Using Thresh Config file /storm/conf/thresh-config.yml. Contents:"
+  cat /storm/conf/thresh-config.yml | grep -vi password
+  JAVAOPTS="-Xmx$(python /heap.py $WORKER_MAX_HEAP_MB)"
+  echo "Submitting storm topology as local cluster using JAVAOPTS of $JAVAOPTS"
+  java $JAVAOPTS -classpath "/monasca-thresh.jar:/storm/lib/*" monasca.thresh.ThresholdingEngine /storm/conf/thresh-config.yml thresh-cluster local
+  exit $?
+fi
+
 echo "Waiting for storm to become available..."
 success="false"
 for i in $(seq $STORM_WAIT_RETRIES); do


### PR DESCRIPTION
Allow the Threshold Engine to optionally run without Storm Nimbus and
Supervisor daemons. Make this the default configuration so remove
Nimbus and Supervisor from docker-compose.yml

Update ci.py for new and removed containers

Fixed CI test for number of jobs