### PR TITLE
Allow API to start without a Mysql database

### DIFF
--- a/monasca-api-python/README.md
+++ b/monasca-api-python/README.md
@@ -85,6 +85,7 @@ A number of environment variables can be passed to the container:
 | `MYSQL_DB`                | `mon`         | MySQL database name              |
 | `MYSQL_WAIT_RETRIES`      | `24`          | # of MySQL connection attempts   |
 | `MYSQL_WAIT_DELAY`        | `5`           | seconds to wait between attempts |
+| `API_MYSQL_DISABLED`      | unset         | if 'true' do not use a mysql database. Only metric API will work |
 | `KEYSTONE_IDENTITY_URI`   | `http://keystone:35357` | Keystone identity address |
 | `KEYSTONE_AUTH_URI`       | `http://keystone:5000`  | Keystone auth address     |
 | `KEYSTONE_ADMIN_USER`     | `admin`       | Keystone admin account user      |

--- a/monasca-api-python/api-config.conf.j2
+++ b/monasca-api-python/api-config.conf.j2
@@ -109,7 +109,9 @@ password = {{ INFLUX_PASSWORD }}
 database_name = {{ INFLUX_DB }}
 
 [database]
+{% if not ( API_MYSQL_DISABLED is defined and API_MYSQL_DISABLED | lower == 'true' ) %}
 connection = "mysql+pymysql://{{ MYSQL_USER }}:{{ MYSQL_PASSWORD }}@{{ MYSQL_HOST }}/{{ MYSQL_DB }}"
+{% endif %}
 
 [keystone_authtoken]
 auth_type = password

--- a/monasca-api-python/start.sh
+++ b/monasca-api-python/start.sh
@@ -11,28 +11,30 @@ MYSQL_WAIT_DELAY=${MYSQL_WAIT_DELAY:-"5"}
 KAFKA_WAIT_RETRIES=${KAFKA_WAIT_RETRIES:-"24"}
 KAFKA_WAIT_DELAY=${KAFKA_WAIT_DELAY:-"5"}
 
-echo "Waiting for MySQL to become available..."
-success="false"
-for i in $(seq $MYSQL_WAIT_RETRIES); do
-  mysqladmin status \
-      --host="$MYSQL_HOST" \
-      --user="$MYSQL_USER" \
-      --password="$MYSQL_PASSWORD" \
-      --connect_timeout=10
-  if [ $? -eq 0 ]; then
-    echo "MySQL is available, continuing..."
-    success="true"
-    break
-  else
-    echo "Connection attempt $i of $MYSQL_WAIT_RETRIES failed"
-    sleep "$MYSQL_WAIT_DELAY"
-  fi
-done
+if [ "$MYSQL_WAIT_RETRIES" != "0" ]; then
+  echo "Waiting for MySQL to become available..."
+  success="false"
+  for i in $(seq $MYSQL_WAIT_RETRIES); do
+    mysqladmin status \
+        --host="$MYSQL_HOST" \
+        --user="$MYSQL_USER" \
+        --password="$MYSQL_PASSWORD" \
+        --connect_timeout=10
+    if [ $? -eq 0 ]; then
+      echo "MySQL is available, continuing..."
+      success="true"
+      break
+    else
+      echo "Connection attempt $i of $MYSQL_WAIT_RETRIES failed"
+      sleep "$MYSQL_WAIT_DELAY"
+    fi
+  done
 
-if [ "$success" != "true" ]; then
-    echo "Unable to reach MySQL database! Exiting..."
-    sleep 1
-    exit 1
+  if [ "$success" != "true" ]; then
+      echo "Unable to reach MySQL database! Exiting..."
+      sleep 1
+      exit 1
+  fi
 fi
 
 if [ -n "$KAFKA_WAIT_FOR_TOPICS" ]; then


### PR DESCRIPTION
This allows just the metrics part of Monasca to run assuming
an external keystone is available

Attempting to query notifications, alarm definitions or alarms
will result in a 500. Use very carefully