### PR TITLE
Bump Zookeeper to 3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     image: monasca/alarms:1.1.0
 
   zookeeper:
-    image: zookeeper:3.3
+    image: zookeeper:3.4
   kafka:
     image: monasca/kafka:0.9.0.1-2.11-1.0.2
     environment:


### PR DESCRIPTION
In monasca upstream, Zookeeper 3.4 is currently used.
However monasca-docker still uses 3.3.

Partially-handles #135