### PR TITLE
Make parts of mysql-init optional

### DIFF
--- a/mysql-init/README.md
+++ b/mysql-init/README.md
@@ -54,6 +54,9 @@ Configuration
 | `MYSQL_INIT_SET_PASSWORD`        | unset | If set, reset password to given value |
 | `MYSQL_INIT_WAIT_RETRIES`        | `24` | Number of connection attempts to make  |
 | `MYSQL_INIT_WAIT_DELAY`          | `5`  | Seconds to wait between retry attempts |
+| `KEYSTONE_DB_ENABLED` | `true`    | Setup Keystone Database. Use `false` with an external Keystone |
+| `CREATE_MON_USERS`    | `true`    | Create the Database users for Monasca |
+| `GRAFANA_DB_ENABLED`  | `true`    | Setup Grafana Database                |
 
 While this image requires access (probably `root`-level) to a MySQL instance at
 startup, `MYSQL_INIT_DISABLE_REMOTE_LOGIN`, `MYSQL_INIT_RANDOM_PASSWORD`, and

--- a/mysql-init/build.yml
+++ b/mysql-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/mysql-init
 variants:
   - tag: latest
     aliases:
-      - :1.5.2
+      - :1.5.3
       - :1.5
       - :1

--- a/mysql-init/init.sh
+++ b/mysql-init/init.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 
-set -x
-
 MYSQL_INIT_HOST=${MYSQL_INIT_HOST:-"mysql"}
 MYSQL_INIT_PORT=${MYSQL_INIT_PORT:-"3306"}
 MYSQL_INIT_USERNAME=${MYSQL_INIT_USERNAME:-"root"}

--- a/mysql-init/init.sh
+++ b/mysql-init/init.sh
@@ -55,7 +55,8 @@ clean_install() {
   done
 
   for f in $USER_SCRIPTS/*.sql; do
-    if [ -e "$f" ]; then
+    # SQL files with zero length are ignored
+    if [ -s "$f" ]; then
       echo "Running script: $f"
       mysql --host="$MYSQL_INIT_HOST" \
           --user="$MYSQL_INIT_USERNAME" \
@@ -159,7 +160,8 @@ schema_upgrade() {
     done
 
     for f in $UPGRADE_SCRIPTS/$diff_version/*.sql; do
-      if [ -e "$f" ]; then
+      # SQL files with zero length are ignored
+      if [ -s "$f" ]; then
         echo "Running script: $f"
         set +x
         mysql --host="$MYSQL_INIT_HOST" \

--- a/mysql-init/mysql-init.d/01-keystone.sql.j2
+++ b/mysql-init/mysql-init.d/01-keystone.sql.j2
@@ -1,3 +1,4 @@
+{% if KEYSTONE_DB_ENABLED | default ('true') | lower == 'true' -%}
 /*
  * (C) Copyright 2017 Hewlett Packard Enterprise Development LP
  *
@@ -20,3 +21,4 @@ CREATE DATABASE IF NOT EXISTS `keystone`;
 {% set keystone_pw = KEYSTONE_PASSWORD | default('keystone') %}
 
 GRANT ALL ON `keystone`.* TO '{{ keystone_user }}'@'%' IDENTIFIED BY '{{ keystone_pw }}';
+{%- endif %}

--- a/mysql-init/mysql-init.d/02-users.sql.j2
+++ b/mysql-init/mysql-init.d/02-users.sql.j2
@@ -1,3 +1,4 @@
+{% if CREATE_MON_USERS | default ('true') | lower == 'true' -%}
 /*
  * To require ssl connections add 'REQUIRE SSL' to the end of all grant statements
  */
@@ -15,3 +16,4 @@ GRANT ALL ON {{ db }}.* TO '{{ monapi_user }}'@'%' IDENTIFIED BY '{{ monapi_pw }
 GRANT ALL ON {{ db }}.* TO '{{ monapi_user }}'@'localhost' IDENTIFIED BY '{{ monapi_pw }}';
 GRANT ALL ON {{ db }}.* TO '{{ thresh_user }}'@'%' IDENTIFIED BY '{{ thresh_pw }}';
 GRANT ALL ON {{ db }}.* TO '{{ thresh_user }}'@'localhost' IDENTIFIED BY '{{ thresh_pw }}';
+{%- endif %}

--- a/mysql-init/mysql-init.d/03-grafana.sql.j2
+++ b/mysql-init/mysql-init.d/03-grafana.sql.j2
@@ -1,3 +1,4 @@
+{% if GRAFANA_DB_ENABLED | default ('true') | lower == 'true' -%}
 {% set grafana_user = GRAFANA_USERNAME | default('grafana') %}
 {% set grafana_password = GRAFANA_PASSWORD | default('password') %}
 
@@ -14,3 +15,4 @@ CREATE TABLE `session` (
 
 GRANT ALL ON grafana.* TO '{{ grafana_user }}'@'%' IDENTIFIED BY '{{ grafana_password }}';
 GRANT ALL ON grafana.* TO '{{ grafana_user }}'@'localhost' IDENTIFIED BY '{{ grafana_password }}';
+{%- endif %}

--- a/mysql-init/mysql-upgrade.d/1.5.0/01-grafana.sql.j2
+++ b/mysql-init/mysql-upgrade.d/1.5.0/01-grafana.sql.j2
@@ -1,3 +1,4 @@
+{% if GRAFANA_DB_ENABLED | default ('true') | lower == 'true' -%}
 {% set grafana_user = GRAFANA_USERNAME | default('grafana') %}
 {% set grafana_password = GRAFANA_PASSWORD | default('password') %}
 
@@ -14,3 +15,4 @@ CREATE TABLE `session` (
 
 GRANT ALL ON grafana.* TO '{{ grafana_user }}'@'%' IDENTIFIED BY '{{ grafana_password }}';
 GRANT ALL ON grafana.* TO '{{ grafana_user }}'@'localhost' IDENTIFIED BY '{{ grafana_password }}';
+{%- endif %}


### PR DESCRIPTION
Allow skipping of creating the database for Keystone. Useful when
using an external Keystone.

Allow skipping of creating mon database users if they have been
created externally.

Allow skipping of Grafana database if it is not configured.