### PR TITLE
Update monasca-api branch

### DIFF
--- a/monasca-api-python/build.yml
+++ b/monasca-api-python/build.yml
@@ -4,4 +4,4 @@ variants:
     aliases:
       - :master-{date}-{time}
     args:
-      API_BRANCH: refs/changes/63/417163/9
+      API_BRANCH: refs/changes/63/417163/10


### PR DESCRIPTION
Updates the API to use the latest version of the prometheus patch [1], rebased on monasca-api HEAD [2] as of 2 August 2017.

[1] https://review.openstack.org/#/c/417163/
[2] 1a0c02bbf9084229150b29e837df7fbe1d9848d7