### PR TITLE
Add keystone-init container

### DIFF
--- a/keystone-init/Dockerfile
+++ b/keystone-init/Dockerfile
@@ -11,6 +11,6 @@ RUN apk add --no-cache ca-certificates && \
     rm -rf /root/.cache/pip && \
     apk del build-dep
 
-COPY keystone_init.py kubernetes.py preload.yml /
+COPY keystone_init.py kubernetes.py preload.yml start.sh /
 
 CMD ["/start.sh"]

--- a/keystone-init/Dockerfile
+++ b/keystone-init/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:2-alpine3.6
+
+COPY requirements.txt stack-fix.c /
+
+RUN apk add --no-cache ca-certificates && \
+    apk add --no-cache --virtual build-dep \
+        musl-dev linux-headers git make g++ && \
+    gcc -shared -fPIC /stack-fix.c -o /stack-fix.so && \
+    pip install urllib3 ipaddress 'pbr>=1.8' && \
+    pip install -r /requirements.txt && \
+    rm -rf /root/.cache/pip && \
+    apk del build-dep
+
+COPY keystone_init.py kubernetes.py preload.yml /
+
+CMD ["sleep", "1000"]

--- a/keystone-init/Dockerfile
+++ b/keystone-init/Dockerfile
@@ -13,4 +13,4 @@ RUN apk add --no-cache ca-certificates && \
 
 COPY keystone_init.py kubernetes.py preload.yml /
 
-CMD ["sleep", "1000"]
+CMD ["/start.sh"]

--- a/keystone-init/build.yml
+++ b/keystone-init/build.yml
@@ -1,0 +1,7 @@
+repository: monasca/keystone-init
+variants:
+  - tag: latest
+    aliases:
+      - 1.0.0
+      - 1.0
+      - 1

--- a/keystone-init/build.yml
+++ b/keystone-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/keystone-init
 variants:
   - tag: latest
     aliases:
-      - 1.0.0
-      - 1.0
-      - 1
+      - :1.0.0
+      - :1.0
+      - :1

--- a/keystone-init/keystone_init.py
+++ b/keystone-init/keystone_init.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import base64
+import logging
+import os
+import random
+import string
+import time
+
+from collections import defaultdict
+from itertools import ifilter
+
+import yaml
+
+from keystoneauth1.exceptions import RetriableConnectionFailure
+from keystoneauth1.identity import Password
+from keystoneauth1.session import Session
+from keystoneclient.discover import Discover
+from requests import HTTPError
+from requests import RequestException
+
+from kubernetes import KubernetesAPIClient
+
+PASSWORD_CHARACTERS = string.ascii_letters + string.digits
+KEYSTONE_PASSWORD_ARGS = [
+    'auth_url', 'username', 'password', 'user_id', 'user_domain_id',
+    'user_domain_name', 'project_id', 'project_name', 'project_domain_id',
+    'project_domain_name', 'tenant_id', 'tenant_name', 'domain_id',
+    'domain_name', 'trust_id', 'default_domain_id', 'default_domain_name'
+]
+KEYSTONE_TIMEOUT = int(os.environ.get('KEYSTONE_TIMEOUT', '10'))
+KEYSTONE_VERIFY = os.environ.get('KEYSTONE_VERIFY', 'true') == 'true'
+KEYSTONE_CERT = os.environ.get('KEYSTONE_CERT', None)
+
+PRELOAD_PATH = os.environ.get('PRELOAD_PATH', '/preload.yml')
+NAMESPACE_FILE = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+
+LOG_LEVEL = logging.getLevelName(os.environ.get('LOG_LEVEL', 'INFO'))
+logging.basicConfig(level=LOG_LEVEL)
+logger = logging.getLogger(__name__)
+
+_domain_cache = []
+_project_cache = defaultdict(lambda: [])
+_role_cache = defaultdict(lambda: [])
+
+
+def first(condition, seq):
+    try:
+        return next(ifilter(condition, seq))
+    except StopIteration:
+        return None
+
+
+class KeystoneInitException(Exception):
+    pass
+
+
+def retry(retries=5, delay=2.0,
+          exc_types=(RetriableConnectionFailure, RequestException)):
+
+    def decorator(func):
+        def f_retry(*args, **kwargs):
+            for i in range(retries):
+                try:
+                    return func(*args, **kwargs)
+                except exc_types as exc:
+                    if i < retries - 1:
+                        logger.debug('Caught exception, retrying...',
+                                     exc_info=True)
+                        time.sleep(delay)
+                    else:
+                        logger.exception('Failed after %d attempts', retries)
+                        if isinstance(exc, RequestException):
+                            logger.debug('Response was: %r', exc.response.text)
+
+                        raise
+        return f_retry
+    return decorator
+
+
+def get_current_namespace():
+    if 'NAMESPACE' in os.environ:
+        return os.environ['NAMESPACE']
+
+    if os.path.exists(NAMESPACE_FILE):
+        with open(NAMESPACE_FILE, 'r') as f:
+            return f.read()
+
+    logger.warn('Not running in cluster and $NAMESPACE is not set, assuming '
+                '\'default\'!')
+    return 'default'
+
+
+def generate_password(length=16):
+    r = random.SystemRandom()
+    return ''.join(r.choice(PASSWORD_CHARACTERS) for _ in range(length))
+
+
+def keystone_args_from_env():
+    ret = {}
+    for arg in KEYSTONE_PASSWORD_ARGS:
+        ret[arg] = os.environ.get('OS_{}'.format(arg.upper()))
+
+    return ret
+
+
+@retry()
+def get_keystone_client():
+    auth = Password(**keystone_args_from_env())
+    session = Session(auth=auth,
+                      app_name='keystone-init',
+                      user_agent='keystone-init',
+                      timeout=KEYSTONE_TIMEOUT,
+                      verify=KEYSTONE_VERIFY,
+                      cert=KEYSTONE_CERT)
+
+    discover = Discover(session=session)
+    return discover.create_client()
+
+
+@retry()
+def get_or_create_domain(client, name=None):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param name:
+    :return: the Domain instance
+    :rtype: keystoneclient.v3.domains.Domain
+    """
+    # default domain should always exist
+    if name is None:
+        return client.domains.get('default')
+
+    if not _domain_cache:
+        _domain_cache.extend(client.domains.list())
+
+    domain = first(lambda d: d.name == name, _domain_cache)
+    if domain:
+        logging.info('found existing domain: %s', domain.name)
+    else:
+        logging.info('creating domain: %s', name)
+        domain = client.domains.create(name)
+        _domain_cache.append(domain)
+        logging.debug('created domain: %s', domain.name)
+
+    return domain
+
+
+@retry()
+def get_or_create_project(client, domain, name):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param domain:
+    :type domain: keystoneclient.v3.domains.Domain
+    :param name: the name of the project
+    :return: the Project instance
+    :rtype: keystoneclient.v3.projects.Project
+    """
+
+    cache = _project_cache[domain.id]
+    if not cache:
+        cache.extend(client.projects.list(domain=domain))
+
+    project = first(lambda p: p.name == name, cache)
+    if project:
+        logging.info('found existing project: %s', project.name)
+    else:
+        logging.info('creating project: %s', name)
+        project = client.projects.create(name, domain)
+        cache.append(project)
+        logging.debug('created project: %r', project)
+
+    return project
+
+
+@retry()
+def get_or_create_role(client, domain, name):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param domain: domain when creating a role, None if global
+    :type domain: keystoneclient.v3.domains.Domain
+    :param name:
+    :return:
+    :rtype: keystoneclient.v3.roles.Role
+    """
+    cache = _role_cache[domain.id]
+    if not cache:
+        # NOTE: client.roles.list() does NOT function like
+        # client.projects.list()! passing `domain=` does not work,
+        # `domain_id=` must be used explicitly
+        cache.extend(client.roles.list(domain_id=domain.id))
+
+    role = first(lambda r: r.name == name, cache)
+    if role:
+        logging.info('found existing role: %s', role.name)
+    else:
+        logging.info('creating role: %s', name)
+        role = client.roles.create(name, domain)
+        cache.append(role)
+        logging.debug('created role: %r', role)
+
+    return role
+
+
+@retry()
+def get_user(client, domain, name):
+    """
+
+    :type client: keystoneclient.v3.client.Client
+    :type domain: keystoneclient.v3.domains.Domain
+    :type name: str
+    :return:
+    :rtype: keystoneclient.v3.users.User
+    """
+    # don't really need to cache users since we only touch each user once
+    return first(lambda u: u.name == name, client.users.list(domain=domain))
+
+
+@retry()
+def create_user(client, username, **kwargs):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param username:
+    :return:
+    :rtype: keystoneclient.v3.users.User
+    """
+    user = client.users.create(username, **kwargs)
+    logging.info("created user %s", username)
+
+    return user
+
+
+@retry()
+def update_user(client, user, **kwargs):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param user:
+    :type user: keystoneclient.v3.users.User
+    :return:
+    """
+    user = client.users.update(user, **kwargs)
+    logging.info('updated user %s', user.name)
+
+
+@retry()
+def get_role_assignments(client, user, project):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param user:
+    :type user: keystoneclient.v3.users.User
+    :param project:
+    :type project: keystoneclient.v3.projects.Project
+    :return:
+    """
+    return client.role_assignments.list(user=user, project=project)
+
+
+@retry()
+def grant_role(client, role_id, user, project):
+    """
+
+    :param client:
+    :type client: keystoneclient.v3.client.Client
+    :param role_id:
+    :type role_id: str
+    :param user:
+    :type user: keystoneclient.v3.users.User
+    :param project:
+    :type project: keystoneclient.v3.projects.Project
+    :return:
+    """
+    client.roles.grant(role_id, user=user, project=project)
+
+
+@retry()
+def ensure_kubernetes_namespace(client, namespace):
+    """
+
+    :type client: kubernetes.KubernetesAPIClient
+    :type namespace: str
+    :return:
+    """
+    try:
+        client.get('/api/v1/namespaces/{}', namespace)
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            logging.info('creating namespace: %s', namespace)
+            client.post('/api/v1/namespaces', json={
+                'apiVersion': 'v1',
+                'kind': 'Namespace',
+                'metadata': {
+                    'name': namespace
+                }
+            })
+
+
+@retry()
+def get_kubernetes_secret(client, name, namespace=None):
+    """
+
+    :param client:
+    :type client: kubernetes.KubernetesAPIClient
+    :param name:
+    :param namespace: namespace, auto if None
+    :return: loaded secret dict or None if it does not exist
+    """
+    if namespace is None:
+        namespace = get_current_namespace()
+
+    try:
+        return client.get('/api/v1/namespaces/{}/secrets/{}', namespace, name)
+    except HTTPError as e:
+        if e.response.status_code != 404:
+            raise
+
+        return None
+
+
+def create_kubernetes_secret(client, fields, name, namespace=None):
+    """
+
+    :param client:
+    :type client: kubernetes.KubernetesAPIClient
+    :param fields:
+    :type fields: dict[str, str]
+    :param name:
+    :param namespace: namespace, auto if None
+    :return:
+    """
+    if namespace is None:
+        namespace = get_current_namespace()
+
+    ensure_kubernetes_namespace(client, namespace)
+
+    encoded = {k: base64.b64encode(v) for k, v in fields.iteritems()}
+    secret = {
+        'kind': 'Secret',
+        'apiVersion': 'v1',
+        'type': 'Opaque',
+        'metadata': {
+            'name': name,
+            'namespace': namespace,
+            'labels': {
+                'heritage': 'keystone-init-job'
+            }
+        },
+        'data': encoded
+    }
+
+    logging.info('creating secret "%s" in namespace "%s"', name, namespace)
+    return client.post('/api/v1/namespaces/{}/secrets',
+                       namespace, json=secret)
+
+
+def parse_secret(secret):
+    if isinstance(secret, basestring):
+        if '/' in secret:
+            namespace, name = secret.split('/', 1)
+            return namespace, name
+        else:
+            return None, secret
+
+    return secret['namespace'], secret['name']
+
+
+def load_domains(ks, k8s, domains):
+    """
+
+    :param ks:
+    :type ks: keystoneclient.v3.client.Client
+    :param k8s:
+    :type k8s: kubernetes.KubernetesAPIClient
+    :param domains:
+    :type domains: dict[str, dict[str, list]]
+    :return:
+    """
+
+    for name, options in domains.iteritems():
+        domain = get_or_create_domain(ks, None if name == 'default' else name)
+
+        logging.info('creating projects...')
+        for project in options.get('projects', []):
+            get_or_create_project(ks, domain, project)
+
+        logging.info('creating roles...')
+        for role in options.get('roles', []):
+            get_or_create_role(ks, domain, role)
+
+        logging.info('creating users...')
+        for user_cfg in options.get('users', []):
+            assert isinstance(user_cfg, dict)
+
+            username = user_cfg.get('username')
+            user = get_user(ks, domain, username)
+
+            if 'project' in user_cfg:
+                # currently assuming all valid projects are at least
+                # referenced in `projects` block
+                project = get_or_create_project(ks, domain, user_cfg['project'])
+            else:
+                project = None
+
+            if user:
+                if hasattr(user, 'project_id') \
+                        and project is not None \
+                        and project.id == user.project_id:
+                    update_user(ks, user, project_id=project.id)
+
+                    logger.info('reassigned user %s to project %s',
+                                user.name, project.name)
+            else:
+                password = user_cfg.get('password', generate_password())
+                email = user_cfg.get('email', None)
+
+                if 'secret' in user_cfg:
+                    s_namespace, s_name = parse_secret(user_cfg['secret'])
+                    secret = get_kubernetes_secret(k8s, s_name, s_namespace)
+                    if secret:
+                        # TODO use password from secret instead? overwrite?
+                        pass
+                    else:
+                        # TODO add more vars? auth url?
+                        create_kubernetes_secret(k8s, {
+                            'OS_USERNAME': username,
+                            'OS_PASSWORD': password
+                        }, s_name, s_namespace)
+                        logging.info('created kubernetes secret: %s/%s',
+                                     s_name, s_namespace)
+
+                # project is supposedly deprecated in favor of default_project
+                # ... but we'll use it anyway
+                user = create_user(ks, username,
+                                   domain=domain, password=password,
+                                   email=email, project=project)
+
+            current_roles = get_role_assignments(ks, user, project)
+            current_ids = set(map(lambda a: a.role['id'], current_roles))
+
+            desired_role_names = user_cfg.get('roles', [])
+            desired_roles = map(lambda n: get_or_create_role(ks, domain, n),
+                                desired_role_names)
+            desired_ids = set(map(lambda r: r.id, desired_roles))
+
+            # TODO should we remove roles that aren't in the list?
+
+            roles_to_grant = desired_ids - current_ids
+            logging.info('granting roles to user: %r', roles_to_grant)
+            for role_id in roles_to_grant:
+                grant_role(ks, role_id, user, project)
+
+        logging.info('finished initializing domain %s', name)
+
+    logging.info('all domains initialized successfully')
+
+
+def load_endpoints(ks, k8s, endpoints):
+    for name, options in endpoints.iteritems():
+        # TODO
+        pass
+
+
+def main():
+    ks = get_keystone_client()
+
+    k8s = KubernetesAPIClient()
+    k8s.load_auto_config()
+
+    with open(PRELOAD_PATH, 'r') as f:
+        preload = yaml.safe_load(f)
+
+        if 'domains' in preload:
+            load_domains(ks, k8s, preload['domains'])
+
+        if 'endpoints' in preload:
+            load_endpoints(ks, k8s, preload['endpoints'])
+
+
+if __name__ == '__main__':
+    main()

--- a/keystone-init/kubernetes.py
+++ b/keystone-init/kubernetes.py
@@ -1,0 +1,170 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+import os
+
+import dpath.util
+import requests
+import yaml
+
+from dotmap import DotMap
+
+CACERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
+KUBE_CONFIG_PATH = os.environ.get('KUBECONFIG', '~/.kube/config')
+
+KUBERNETES_SERVICE_HOST = os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default')
+KUBERNETES_SERVICE_PORT = os.environ.get('KUBERNETES_SERVICE_PORT', '443')
+KUBERNETES_API_URL = "https://{}:{}".format(KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT)
+
+DEFAULT_TIMEOUT = 10
+
+
+def load_current_kube_credentials():
+    with open(os.path.expanduser(KUBE_CONFIG_PATH), 'r') as f:
+        config = DotMap(yaml.safe_load(f))
+
+        ctx_name = config['current-context']
+        ctx = next(c for c in config.contexts if c.name == ctx_name)
+        cluster = next(c for c in config.clusters if c.name == ctx.context.cluster).cluster
+
+        if 'certificate-authority' in cluster:
+            ca_cert = cluster['certificate-authority']
+        else:
+            ca_cert = None
+
+        if ctx.context.user:
+            user = next(u for u in config.users if u.name == ctx.context.user).user
+            return cluster.server, ca_cert, (user['client-certificate'], user['client-key'])
+        else:
+            return cluster.server, ca_cert, None
+
+
+class KubernetesAPIError(Exception):
+    pass
+
+
+class KubernetesAPIResponse(DotMap):
+
+    def __init__(self, response, decoded=None):
+        super(KubernetesAPIResponse, self).__init__(decoded, _dynamic=False)
+        self.response = response
+
+    def get(self, glob, separator="/"):
+        return dpath.util.get(self, glob, separator)
+
+    def search(self, glob, yielded=False, separator="/", afilter=None, dirs=True):
+        return dpath.util.search(self, glob, yielded, separator, afilter, dirs)
+
+    def set(self, glob, value):
+        return dpath.util.set(self, glob, value)
+
+    def new(self, path, value):
+        return dpath.util.new(self, path, value)
+
+    @property
+    def status_code(self):
+        return self.response.status_code
+
+
+class KubernetesAPIClient(object):
+    def __init__(self, verify=True):
+        self.session = requests.Session()
+        self.session.verify = verify
+        self.api_url = None
+
+    def load_cluster_config(self):
+        self.session.verify = CACERT_PATH
+
+        # requests will purge request Content-Type headers if we hit a
+        # redirect, so try to avoid running into one because of an extra /
+        self.api_url = KUBERNETES_API_URL.rstrip('/')
+
+        with open(TOKEN_PATH, 'r') as f:
+            token = f.read()
+            self.session.headers.update({
+                'Authorization': 'Bearer {}'.format(token)
+            })
+
+    def load_kube_config(self):
+        server, ca_cert, cert = load_current_kube_credentials()
+        self.api_url = server.rstrip('/')
+        self.session.cert = cert
+        self.session.verify = ca_cert
+
+        if self.api_url.endswith('/'):
+            self.api_url = self.api_url.rstrip('/')
+
+    def load_auto_config(self):
+        if os.path.exists(os.path.expanduser(KUBE_CONFIG_PATH)):
+            self.load_kube_config()
+        elif os.path.exists(TOKEN_PATH):
+            self.load_cluster_config()
+        else:
+            raise KubernetesAPIError('No supported API configuration found!')
+
+    def request(self, method, path, *args, **kwargs):
+        raise_for_status = kwargs.pop('raise_for_status', True)
+        timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT)
+
+        if args:
+            path = path.format(*args)
+
+        slash = '' if path.startswith('/') else '/'
+        res = self.session.request(
+            method,
+            '{}{}{}'.format(self.api_url, slash, path),
+            timeout=timeout,
+            **kwargs)
+
+        if raise_for_status:
+            res.raise_for_status()
+
+        return KubernetesAPIResponse(res, res.json())
+
+    def get(self, path, *args, **kwargs):
+        kwargs.setdefault('allow_redirects', True)
+        return self.request('GET', path, *args, **kwargs)
+
+    def post(self, path, *args, **kwargs):
+        return self.request('POST', path, *args, **kwargs)
+
+    def delete(self, path, *args, **kwargs):
+        return self.request('DELETE', path, *args, **kwargs)
+
+    def patch(self, path, *args, **kwargs):
+        return self.request('PATCH', path, *args, **kwargs)
+
+    def json_patch(self, ops, path, *args, **kwargs):
+        if kwargs.get('allow_redirects') is True:
+            raise ValueError('Patch is not compatible with redirects!')
+
+        headers = kwargs.pop('headers', None)
+        if headers:
+            headers = headers.copy()
+        else:
+            headers = {}
+
+        headers['Content-Type'] = 'application/json-patch+json'
+        resp = self.patch(path,
+                          data=json.dumps(ops), headers=headers,
+                          allow_redirects=False,
+                          *args, **kwargs)
+        if 300 <= resp.status_code < 400:
+            raise KubernetesAPIError('Encountered a redirect while sending a '
+                                     'PATCH, failing!')
+
+        return resp

--- a/keystone-init/preload.yml
+++ b/keystone-init/preload.yml
@@ -1,0 +1,5 @@
+domains:
+  default:
+    projects: []
+    roles: []
+    users: []

--- a/keystone-init/requirements.txt
+++ b/keystone-init/requirements.txt
@@ -1,0 +1,6 @@
+dpath
+dotmap
+pbr>=1.8
+keystoneauth1
+python-keystoneclient>=3.8.0 # Apache-2.0
+requests

--- a/keystone-init/stack-fix.c
+++ b/keystone-init/stack-fix.c
@@ -1,0 +1,30 @@
+// workaround for musl's small stack size causing python segfaults
+// https://github.com/esnme/ultrajson/issues/254#issuecomment-314862445
+
+#include <dlfcn.h>
+
+#include <pthread.h>
+
+typedef int (*func_t)(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg);
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg) {
+	pthread_attr_t local;
+	int used = 0, ret;
+
+	if (!attr) {
+		used = 1;
+		pthread_attr_init(&local);
+		attr = &local;
+	}
+	pthread_attr_setstacksize((void*)attr, 2 * 1024 * 1024); // 2 MB
+
+	func_t orig = (func_t)dlsym(RTLD_NEXT, "pthread_create");
+
+	ret = orig(thread, attr, start_routine, arg);
+
+	if (used) {
+		pthread_attr_destroy(&local);
+	}
+
+	return ret;
+}

--- a/keystone-init/start.sh
+++ b/keystone-init/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+LD_PRELOAD=/stack-fix.so python keystone_init.py


### PR DESCRIPTION
This adds a new container capable of creating accounts in keystone.
It randomly generates passwords at first start and stores them in
Kubernetes secrets, bypassing Helm so that the secrets can be stored
securely.

Note that the container currently requires a Kubernetes environment,
support for running in docker will be added in the future. Eventually
this should replace most of our keystone bootstrapping logic.