### PR TITLE
Misc keystone-init improvements

### DIFF
--- a/keystone-init/README.md
+++ b/keystone-init/README.md
@@ -1,0 +1,182 @@
+keystone-init Dockerfile
+========================
+
+This image creates resources in an existing Keystone deployment .
+
+Sources: [keystone-init][1] &middot; [Dockerfile][2] &middot; [monasca-docker][3]
+
+Tags
+----
+
+Images in this repository are tagged as follows:
+
+ * `latest`: refers to the latest stable point release, e.g. `1.0.0`
+ * `1.0.0`, `1.0`, `1`: standard semver tags
+
+Usage
+-----
+
+This image requires access to a running Keystone instance, along with valid
+Keystone credentials with permission to create additional Keystone resources.
+
+The job is intended to be run only once like so, and requires no persistent
+storage:
+
+    docker run --rm=true monasca/keystone-init:latest
+
+If needed, connection parameters can be provided via environment variables as
+described below. This script should be idempotent and will either leave Keystone
+in the desired state or return an error. Subsequent executions will create or
+potentially modify resources if the preload configuration changes but will
+otherwise leave unchanged resources unchanged.
+
+Note that the [Helm chart][4] can be used in a Kubernetes environment to easily
+configure and run the job.
+
+Configuration
+-------------
+
+| Variable           | Default          | Description                     |
+|--------------------|------------------|---------------------------------|
+| `LOG_LEVEL`        | `INFO` | MySQL server host               |
+| `KEYSTONE_TIMEOUT` | `10`   | MySQL server port               |
+| `KEYSTONE_VERIFY`  | `true` | MySQL user w/ needed privileges |
+| `KEYSTONE_CERT`    | unset  | Password for given user         |
+| `OS_AUTH_URL`      | unset  | (**required**)    |
+| `OS_USERNAME`      | unset  | If `true`, disable remote root login  |
+| `OS_PASSWORD`            | unset | If set, reset password to given value |
+| `OS_USER_DOMAIN_NAME`    | `24` |   |
+| `OS_PROJECT_NAME`        | `5`  | Seconds to wait between retry attempts |
+| `OS_PROJECT_DOMAIN_NAME` | `5`  | Seconds to wait between retry attempts |
+
+Note that *all* `OS_` variables listed above are **required** but unset by
+default. Many other standard Keystone environment variables (`OS_`) are also
+supported but not generally needed; for a full list see [`keystone_init.py`][5].
+
+Preload configuration
+---------------------
+
+A single file, `/preload.yml`, should be mounted into the container to provide
+preload configuration. The default config file is empty, and should be
+overridden for this container to be of any use.
+
+An empty config file looks as follows:
+
+```yaml
+domains:
+  default:
+    projects: []
+    roles: []
+    users: []
+```
+
+Domains are created by their unique name *except* for `default`, which
+references the Keystone domain with the literal ID `default`. If you wish to
+create a domain with no additional resources, define it like so:
+
+```yaml
+domains:
+  example: {}
+```
+
+Projects, roles, and users are unique within a domain, and can be defined as
+lists of strings under their respective YAML blocks. For example:
+
+```yaml
+domains:
+  default:
+    projects:
+      - demo-project
+
+    roles:
+      - demo-role
+```
+
+The `users` block accepts a list of objects. As an example:
+
+```yaml
+domains:
+  default:
+    # ...
+    users:
+      - username: test-user
+        project: some-project
+        roles: [a, b, c]
+        secret: some-secret-name
+```
+
+Each defined user will have its Keystone `project` set to the resolved ID of
+the project name provided in the preload config. If the user should not be
+assigned to a project, the field can be ignored. The user will also have each
+resolved role applied. Projects and roles that do not exist will be created
+(note that projects and roles *do not* need to be defined in the `projects` or
+`roles` blocks).
+
+If the `password` field is not specified (recommended!) a password will be
+randomly generated using the system's CSPRNG. When a `secret` field is specified
+(also recommended!), a Kubernetes secret of the same name will be created as
+well, in (by default) the namespace from which the job is run. If desired,
+secrets can be specified in multiple ways:
+
+```yaml
+# will create in the job's namespace
+secret: some-secret  
+
+# will create in 'some-namespace'
+secret: some-namespace/some-secret
+
+# will create in some namespace
+secret:
+  namespace: some-namespace
+  name: some-secret
+```
+
+Note that specifying a `secret` field in a Docker-only environment will result
+in an error, as for now secret management is only available in Kubernetes.
+Consequently, random password generation is probably undesirable in plain Docker
+environments given there is no ability to save the generated password anywhere.
+In this case, a `password` field can be added to user objects to manually
+provide a password.
+
+Generated secrets will include several fields in the style of standard `OS_`
+auth variables. If using Helm, we recommend using [`_keystone_env.tpl`][6] from
+the [keystone-init][4] chart to consume these.
+
+As an example, given this `values.yaml`:
+```yaml
+# in values.yaml
+my_pod:
+  auth:
+    url:
+      secret_name: some-secret
+    username:
+      secret_name: some-secret
+    password:
+      secret_name: some-secret
+    user_domain_name:
+      secret_name: some-secret
+    project_name:
+      secret_name: some-secret
+    project_domain_name:
+      secret_name: some-secret
+```
+
+Then this pod spec will include secrets using the `keystone_env` template:
+```yaml
+# snippet from an example Kubernetes Pod spec
+containers:
+  - name: some-name
+    image: some-image
+    env:
+      - name: MY_VAR
+        value: some-value
+# adjust indent() as necessary
+{{ include "keystone_env" .Values.my_pod.auth | indent(6) }}
+```
+
+[1]: https://github.com/hpcloud-mon/monasca-docker/blob/master/mysql-init/
+[2]: https://github.com/hpcloud-mon/monasca-docker/blob/master/mysql-init/Dockerfile
+[3]: https://github.com/hpcloud-mon/monasca-docker/
+[4]: https://github.com/monasca/monasca-helm/tree/master/keystone-init
+[5]: https://github.com/monasca/monasca-docker/blob/7a7a6032c29ebba3a33e6af29566fd26243cf3ba/keystone-init/keystone_init.py#L39
+[6]: https://github.com/monasca/monasca-helm/blob/master/keystone-init/templates/_keystone_env.tpl

--- a/keystone-init/build.yml
+++ b/keystone-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/keystone-init
 variants:
   - tag: latest
     aliases:
-      - :1.0.1
+      - :1.0.2
       - :1.0
       - :1


### PR DESCRIPTION
- add a README.md
 - remove hard dependency on k8s
   (caveat in docker is plaintext passwords, explained in README)
 - provide more Keystone variables in generated k8s Secrets
   (auth URL, user domain, project name+domain)