### PR TITLE
Add mysql-users-init container

### DIFF
--- a/mysql-users-init/Dockerfile
+++ b/mysql-users-init/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.6-alpine3.6
+
+# To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
+# `docker build`
+ARG REBUILD=1
+
+COPY requirements.txt stack-fix.c /
+
+RUN apk add --no-cache ca-certificates tini && \
+    apk add --no-cache --virtual build-dep \
+        musl-dev linux-headers git make g++ && \
+    gcc -shared -fPIC /stack-fix.c -o /stack-fix.so && \
+    pip install urllib3 ipaddress && \
+    pip install -r /requirements.txt && \
+    rm -rf /root/.cache/pip && \
+    apk del build-dep
+
+COPY mysql_init.py kubernetes.py preload.yml start.sh /
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/start.sh"]

--- a/mysql-users-init/README.md
+++ b/mysql-users-init/README.md
@@ -1,0 +1,170 @@
+mysql-users-init Dockerfile
+===========================
+
+This image creates MySQL users and databases and can store the resulting
+connection details in a Kubernetes secret.
+
+Sources: [mysql-users-init][1] &middot; [Dockerfile][2] &middot; [monasca-docker][3]
+
+Tags
+----
+
+Images in this repository are tagged as follows:
+
+ * `latest`: refers to the latest stable point release, e.g. `1.0.0`
+ * `1.0.0`, `1.0`, `1`: standard semver tags
+
+Usage
+-----
+
+This image requires access to a running MySQL server instance, along with valid
+credentials with permission to create additional databases and users.
+
+The job is intended to be run only once like so, and requires no persistent
+storage:
+
+    docker run --rm=true monasca/mysql-users-init:latest
+
+If needed, connection parameters can be provided via environment variables as
+described below. This script should be idempotent and will either leave MySQL
+in the desired state or return an error. Subsequent executions will create or
+potentially modify resources if the preload configuration changes but will
+otherwise leave unchanged resources unchanged.
+
+Note that the [Helm chart][4] can be used in a Kubernetes environment to easily
+configure and run the job.
+
+Configuration
+-------------
+
+| Variable              | Default              | Description                  |
+|-----------------------|----------------------|------------------------------|
+| `LOG_LEVEL`           | `INFO`               | Log level (`INFO`, `DEBUG`)  |
+| `MYSQL_INIT_HOST`     | unset (**required**) | MySQL hostname               |
+| `MYSQL_INIT_PORT`     | unset (**required**) | MySQL TCP port               |
+| `MYSQL_INIT_USERNAME` | unset (**required**) | MySQL username               |
+| `MYSQL_INIT_PASSWORD` | unset (**required**) | MySQL password               |
+| `PRELOAD_PATH`        | `/preload.yml`       | Path to preload file to read |
+| `NAMESPACE`           | unset (autodetect)   | K8s namespace                |
+
+Preload configuration
+---------------------
+
+A single file, `/preload.yml`, should be mounted into the container to provide
+preload configuration. The default config file is empty, and should be
+overridden for this container to be of any use.
+
+An empty config file looks as follows:
+
+```yaml
+users: []
+databases: []
+```
+
+### Users
+
+The `users` list accepts an arbitary number of user objects. Minimally these
+should contain a username and a secret name:
+
+```yaml
+users:
+  # recommended config, secret will be created in the job's namespace
+  - username: example-user
+    secret: mysql-example-user
+
+  # the secret's namespace can be specified directly too
+  - username: another-user
+    secret:
+      namespace: some-namespace
+      name: mysql-example-user
+
+  # if desired a hardcoded password can be used
+  - username: other-user
+    password: hunter2
+
+  # hostnames can be specified too (['%', localhost] by default)
+  # be wary of the 16 character username limit!
+  - username: user4
+    secret: mysql-user4
+    host: '172.17.0.2' # either a string or list of strings
+```
+
+One `CREATE USER ...` query will be run per host per user that does not already
+exist on the server. Note that `GRANT ...` queries during database creation (see
+below) are handled similarly, using the hosts defined here.
+
+If a user is to be created and a Kubernetes secret with the defined name already
+exists, the existing password will be extracted from the secret and reused.
+Otherwise, a new, random password will be generated and a secret will be
+created.
+
+Note that specifying a `secret` field in a Docker-only environment will result
+in an error, as for now secret management is only available in Kubernetes.
+Consequently, random password generation is probably undesirable in plain Docker
+environments given there is no ability to save the generated password anywhere.
+In this case, a `password` field can be added to user objects to manually
+provide a password.
+
+Each generated secret contains the following fields: `username`, `password`,
+`host`, `port`
+
+### Databases
+
+Databases minimally require a name and a list of grants. Grants should generally
+refer to a user defined in the `users` list:
+
+```yaml
+databases:
+  - name: example-database
+    grants:
+      - example-user
+```
+
+In the above, two `GRANT ALL ...` queries are run, for `example-user@localhost`
+and `example-user@%` (based on the hosts implicitly defined in the
+example-users's definition in the `users` list).
+
+Additional optional fields are available:
+```yaml
+databases:
+  - name: another-database
+    charset: utf8mb4
+    collation: utf8mb4_unicode_ci
+```
+
+If either `charset` or `collation` are unset, the server's default values are
+used.
+
+Additionally, if desired more finely-grained privilege grants can be specified:
+```yaml
+databases:
+  - name: other-database
+    grants:
+      - other-user # ALL by default
+
+      # hosts can be overridden (pulled from users block by default)
+      - username: another-user
+        host: localhost
+
+      # specific privileges can be granted
+      - username: other-user
+        privileges:
+          - select
+          - insert
+
+      # comma-separated strings are okay too
+      - username: user4
+        privileges: create, drop
+```
+
+Some notes about privilege grants:
+ - Only database-level GRANTs are supported
+ - The `NO_AUTO_CREATE_USER` MySQL server option is explicitly enabled, so
+   attempting to grant privileges to any user/host combination that hasn't been
+   explicitly created will result in an error.
+
+
+[1]: https://github.com/monasca/monasca-docker/blob/master/mysql-users-init/
+[2]: https://github.com/monasca/monasca-docker/blob/master/mysql-users-init/Dockerfile
+[3]: https://github.com/monasca/monasca-docker/
+[4]: https://github.com/monasca/monasca-helm/tree/master/mysql-users-init

--- a/mysql-users-init/build.yml
+++ b/mysql-users-init/build.yml
@@ -1,0 +1,7 @@
+repository: monasca/mysql-users-init
+variants:
+  - tag: latest
+    aliases:
+      - :1.0.0
+      - :1.0
+      - :1

--- a/mysql-users-init/kubernetes.py
+++ b/mysql-users-init/kubernetes.py
@@ -1,0 +1,170 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+import os
+
+import dpath.util
+import requests
+import yaml
+
+from dotmap import DotMap
+
+CACERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
+KUBE_CONFIG_PATH = os.environ.get('KUBECONFIG', '~/.kube/config')
+
+KUBERNETES_SERVICE_HOST = os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default')
+KUBERNETES_SERVICE_PORT = os.environ.get('KUBERNETES_SERVICE_PORT', '443')
+KUBERNETES_API_URL = "https://{}:{}".format(KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT)
+
+DEFAULT_TIMEOUT = 10
+
+
+def load_current_kube_credentials():
+    with open(os.path.expanduser(KUBE_CONFIG_PATH), 'r') as f:
+        config = DotMap(yaml.safe_load(f))
+
+        ctx_name = config['current-context']
+        ctx = next(c for c in config.contexts if c.name == ctx_name)
+        cluster = next(c for c in config.clusters if c.name == ctx.context.cluster).cluster
+
+        if 'certificate-authority' in cluster:
+            ca_cert = cluster['certificate-authority']
+        else:
+            ca_cert = None
+
+        if ctx.context.user:
+            user = next(u for u in config.users if u.name == ctx.context.user).user
+            return cluster.server, ca_cert, (user['client-certificate'], user['client-key'])
+        else:
+            return cluster.server, ca_cert, None
+
+
+class KubernetesAPIError(Exception):
+    pass
+
+
+class KubernetesAPIResponse(DotMap):
+
+    def __init__(self, response, decoded=None):
+        super(KubernetesAPIResponse, self).__init__(decoded, _dynamic=False)
+        self.response = response
+
+    def get(self, glob, separator="/"):
+        return dpath.util.get(self, glob, separator)
+
+    def search(self, glob, yielded=False, separator="/", afilter=None, dirs=True):
+        return dpath.util.search(self, glob, yielded, separator, afilter, dirs)
+
+    def set(self, glob, value):
+        return dpath.util.set(self, glob, value)
+
+    def new(self, path, value):
+        return dpath.util.new(self, path, value)
+
+    @property
+    def status_code(self):
+        return self.response.status_code
+
+
+class KubernetesAPIClient(object):
+    def __init__(self, verify=True):
+        self.session = requests.Session()
+        self.session.verify = verify
+        self.api_url = None
+
+    def load_cluster_config(self):
+        self.session.verify = CACERT_PATH
+
+        # requests will purge request Content-Type headers if we hit a
+        # redirect, so try to avoid running into one because of an extra /
+        self.api_url = KUBERNETES_API_URL.rstrip('/')
+
+        with open(TOKEN_PATH, 'r') as f:
+            token = f.read()
+            self.session.headers.update({
+                'Authorization': 'Bearer {}'.format(token)
+            })
+
+    def load_kube_config(self):
+        server, ca_cert, cert = load_current_kube_credentials()
+        self.api_url = server.rstrip('/')
+        self.session.cert = cert
+        self.session.verify = ca_cert
+
+        if self.api_url.endswith('/'):
+            self.api_url = self.api_url.rstrip('/')
+
+    def load_auto_config(self):
+        if os.path.exists(os.path.expanduser(KUBE_CONFIG_PATH)):
+            self.load_kube_config()
+        elif os.path.exists(TOKEN_PATH):
+            self.load_cluster_config()
+        else:
+            raise KubernetesAPIError('No supported API configuration found!')
+
+    def request(self, method, path, *args, **kwargs):
+        raise_for_status = kwargs.pop('raise_for_status', True)
+        timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT)
+
+        if args:
+            path = path.format(*args)
+
+        slash = '' if path.startswith('/') else '/'
+        res = self.session.request(
+            method,
+            '{}{}{}'.format(self.api_url, slash, path),
+            timeout=timeout,
+            **kwargs)
+
+        if raise_for_status:
+            res.raise_for_status()
+
+        return KubernetesAPIResponse(res, res.json())
+
+    def get(self, path, *args, **kwargs):
+        kwargs.setdefault('allow_redirects', True)
+        return self.request('GET', path, *args, **kwargs)
+
+    def post(self, path, *args, **kwargs):
+        return self.request('POST', path, *args, **kwargs)
+
+    def delete(self, path, *args, **kwargs):
+        return self.request('DELETE', path, *args, **kwargs)
+
+    def patch(self, path, *args, **kwargs):
+        return self.request('PATCH', path, *args, **kwargs)
+
+    def json_patch(self, ops, path, *args, **kwargs):
+        if kwargs.get('allow_redirects') is True:
+            raise ValueError('Patch is not compatible with redirects!')
+
+        headers = kwargs.pop('headers', None)
+        if headers:
+            headers = headers.copy()
+        else:
+            headers = {}
+
+        headers['Content-Type'] = 'application/json-patch+json'
+        resp = self.patch(path,
+                          data=json.dumps(ops), headers=headers,
+                          allow_redirects=False,
+                          *args, **kwargs)
+        if 300 <= resp.status_code < 400:
+            raise KubernetesAPIError('Encountered a redirect while sending a '
+                                     'PATCH, failing!')
+
+        return resp

--- a/mysql-users-init/mysql_init.py
+++ b/mysql-users-init/mysql_init.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import base64
+import logging
+import os
+import random
+import string
+import time
+
+from typing import (List, Dict, Union, Sequence, Iterable,
+                    TypeVar, Callable, Optional, Any)
+
+import pymysql
+import yaml
+
+from pymysql.connections import Connection
+from pymysql.err import OperationalError
+from requests import HTTPError
+from requests import RequestException
+
+from kubernetes import KubernetesAPIClient, KubernetesAPIResponse
+
+PASSWORD_CHARACTERS = string.ascii_letters + string.digits
+
+PRELOAD_PATH = os.environ.get('PRELOAD_PATH', '/preload.yml')
+NAMESPACE_FILE = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+
+LOG_LEVEL = logging.getLevelName(os.environ.get('LOG_LEVEL', 'INFO'))
+logging.basicConfig(level=LOG_LEVEL)
+logger = logging.getLogger(__name__)
+
+_kubernetes_client = None
+
+T = TypeVar('T')
+
+
+def first(condition: Callable[[T], bool], seq: Sequence[T]) -> Optional[T]:
+    try:
+        return next(filter(condition, seq))
+    except StopIteration:
+        return None
+
+
+class MySQLInitException(Exception):
+    pass
+
+
+def retry(retries=5, delay=2.0,
+          exc_types=(OperationalError, RequestException)):
+
+    def decorator(func):
+        def f_retry(*args, **kwargs):
+            for i in range(retries):
+                try:
+                    return func(*args, **kwargs)
+                except exc_types as exc:
+                    if i < retries - 1:
+                        logger.info('%s failed (attempt %d of %d)',
+                                    func.__name__, i + 1, retries)
+                        logger.debug('Caught exception, retrying...',
+                                     exc_info=True)
+                        time.sleep(delay)
+                    else:
+                        logger.exception('Failed after %d attempts', retries)
+                        if isinstance(exc, RequestException):
+                            logger.debug('Response was: %r', exc.response.text)
+
+                        raise
+        return f_retry
+    return decorator
+
+
+def get_current_namespace() -> str:
+    if 'NAMESPACE' in os.environ:
+        return os.environ['NAMESPACE']
+
+    if os.path.exists(NAMESPACE_FILE):
+        with open(NAMESPACE_FILE, 'r') as f:
+            return f.read()
+
+    logger.warning('Not running in cluster and $NAMESPACE is not set, '
+                   'assuming \'default\'!')
+    return 'default'
+
+
+def get_kubernetes_client() -> KubernetesAPIClient:
+    global _kubernetes_client
+
+    if _kubernetes_client is None:
+        _kubernetes_client = KubernetesAPIClient()
+        _kubernetes_client.load_auto_config()
+
+    return _kubernetes_client
+
+
+def generate_password(length=16) -> str:
+    r = random.SystemRandom()
+    return ''.join(r.choice(PASSWORD_CHARACTERS) for _ in range(length))
+
+
+@retry(retries=10, delay=5.0)
+def get_mysql_client() -> Connection:
+    return pymysql.connect(host=os.environ.get('MYSQL_INIT_HOST'),
+                           port=int(os.environ.get('MYSQL_INIT_PORT', '3306')),
+                           user=os.environ.get('MYSQL_INIT_USERNAME'),
+                           password=os.environ.get('MYSQL_INIT_PASSWORD'),
+                           cursorclass=pymysql.cursors.DictCursor,
+                           charset='utf8mb4',
+                           sql_mode='NO_AUTO_CREATE_USER')
+
+
+@retry()
+def missing_hosts_for_user(client: Connection,
+                           name: str,
+                           hosts: List[str]) -> List[str]:
+    """
+
+    :param client:
+    :param name: the user name
+    :param hosts: a list of expected user hosts
+    :return: true if user with given name exists, false if not
+    """
+    with client.cursor() as c:
+        c.execute('select `Host` from mysql.user where `User` = %s',
+                  (name,))
+        found_hosts = map(lambda r: r['Host'], c.fetchall())
+
+        return list(set(hosts) - set(found_hosts))
+
+
+@retry()
+def ensure_kubernetes_namespace(client: KubernetesAPIClient, namespace: str):
+    try:
+        client.get('/api/v1/namespaces/{}', namespace)
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            logging.info('creating namespace: %s', namespace)
+            client.post('/api/v1/namespaces', json={
+                'apiVersion': 'v1',
+                'kind': 'Namespace',
+                'metadata': {
+                    'name': namespace
+                }
+            })
+
+
+@retry()
+def get_kubernetes_secret(name: str,
+                          namespace: str=None) -> Union[KubernetesAPIResponse,
+                                                        None]:
+    """
+    :return: loaded secret dict or None if it does not exist
+    """
+    client = get_kubernetes_client()
+
+    if namespace is None:
+        namespace = get_current_namespace()
+
+    try:
+        return client.get('/api/v1/namespaces/{}/secrets/{}', namespace, name)
+    except HTTPError as e:
+        if e.response.status_code != 404:
+            raise
+
+        return None
+
+
+def create_kubernetes_secret(fields: Dict[str, str],
+                             name: str,
+                             namespace: str=None):
+    """
+
+    :param fields:
+    :param name:
+    :param namespace: namespace, auto if None
+    :return:
+    """
+    client = get_kubernetes_client()
+
+    if namespace is None:
+        namespace = get_current_namespace()
+
+    ensure_kubernetes_namespace(client, namespace)
+
+    def prep(value):
+        return base64.b64encode(value.encode('utf-8')).decode('utf-8')
+
+    encoded = {k: prep(v) for k, v in fields.items()}
+    secret = {
+        'kind': 'Secret',
+        'apiVersion': 'v1',
+        'type': 'Opaque',
+        'metadata': {
+            'name': name,
+            'namespace': namespace,
+            'labels': {
+                'heritage': 'mysql-users-init-job'
+            }
+        },
+        'data': encoded
+    }
+
+    logging.info('creating secret "%s" in namespace "%s"', name, namespace)
+    return client.post('/api/v1/namespaces/{}/secrets',
+                       namespace, json=secret)
+
+
+def parse_secret(secret: Union[str, Dict[str, str]]):
+    if isinstance(secret, str):
+        if '/' in secret:
+            namespace, name = secret.split('/', 1)
+            return namespace, name
+        else:
+            return None, secret
+
+    return secret['namespace'], secret['name']
+
+
+def get_or_create_password(client: Connection,
+                           user: Dict[str, Any]) -> str:
+    if 'password' in user:
+        return user['password']
+    elif 'secret' in user:
+        s_namespace, s_name = parse_secret(user['secret'])
+        existing_secret = get_kubernetes_secret(s_name, s_namespace)
+
+        if existing_secret:
+            # the password already exists, so try to use it (else we would put
+            # whichever service consumes this secret in an invalid state)
+
+            if 'password' not in existing_secret.data:
+                # probably not recoverable, short of deleting the existing
+                # secret and re-creating (which would be awful in its own way)
+                raise MySQLInitException('existing secret %s is '
+                                         'invalid' % s_name)
+
+            logging.info('will use existing password from secret %s for user '
+                         '%s' % (s_name, user['username']))
+            pass_bytes = base64.b64decode(existing_secret.data['password'])
+            return pass_bytes.decode('utf-8')
+        else:
+            password = generate_password()
+            create_kubernetes_secret({
+                'username': user['username'],
+                'password': password,
+                'host': client.host,
+                'port': str(client.port)
+            }, s_name, s_namespace)
+
+            return password
+
+
+def create_user(client: Connection, username: str, host: str, password: str):
+    with client.cursor() as c:
+        c.execute('CREATE USER %s@%s IDENTIFIED BY %s',
+                  (username, host, password))
+
+
+def flush_privileges(client: Connection):
+    with client.cursor() as c:
+        logging.debug('flushing privileges...')
+        c.execute('FLUSH PRIVILEGES;')
+
+
+def get_current_databases(client: Connection) -> Iterable[str]:
+    with client.cursor() as c:
+        c.execute('SHOW DATABASES;')
+        return map(lambda r: r['Database'], c.fetchall())
+
+
+def create_database(client: Connection, name: str,
+                    charset: str=None, collation: str=None):
+    if charset:
+        charset_part = ' DEFAULT CHARACTER SET %s' % charset
+    else:
+        charset_part = ''
+
+    if collation:
+        collation_part = ' DEFAULT COLLATE %s' % collation
+    else:
+        collation_part = ''
+
+    with client.cursor() as c:
+        c.execute('CREATE DATABASE %s%s%s' % (
+            name, charset_part, collation_part
+        ))
+
+
+def grant_privileges(client: Connection,
+                     database: str,
+                     privileges: List[str],
+                     user: str, host: str):
+    with client.cursor() as c:
+        privs = ', '.join(p.upper() for p in privileges)
+        c.execute('GRANT %s ON %s.* TO \'%s\'@\'%s\'' % (
+            privs, database, user, host
+        ))
+
+        logging.info('granted %s on %s to %s@%s', privs, database, user, host)
+
+
+def load_grant(client: Connection, database: str,
+               grant: Union[str, Dict[str, Any]],
+               known_hosts: Dict[str, List[str]]):
+    # note: sql grants are idempotent so we'll just apply them every time
+    # note: only database-level privileges can be granted
+    if isinstance(grant, str):
+        # just a username
+        hosts = known_hosts.get(grant, None)
+        if not hosts:
+            hosts = ['%']
+
+        for host in hosts:
+            grant_privileges(client, database, ['ALL'], grant, host)
+    else:
+        # block with optional hosts override / privileges
+        username = grant['username']
+        privileges = grant['privileges']
+        if isinstance(privileges, str):
+            privileges = map(lambda p: p.strip(), privileges.split(','))
+
+        if 'host' in grant:
+            hosts = grant['host']
+            if isinstance(hosts, str):
+                hosts = [hosts]
+        else:
+            hosts = known_hosts.get(username, None) or ['%']
+
+        for host in hosts:
+            grant_privileges(client, database, privileges, username, host)
+
+
+def load_users(client: Connection,
+               users: List[Dict[str, Union[List, str]]]) -> Dict[str, List]:
+    known_hosts = {}
+
+    for user in users:
+        username = user['username']
+        if 'host' in user:
+            hosts = user['host']
+            if isinstance(hosts, str):
+                hosts = [hosts]
+        else:
+            hosts = ['%', 'localhost']
+
+        known_hosts[username] = hosts
+
+        hosts_to_create = missing_hosts_for_user(client, username, hosts)
+        if hosts_to_create:
+            logging.info('creating user %s for hosts: %r', username,
+                         hosts_to_create)
+
+            password = get_or_create_password(client, user)
+            for host in hosts_to_create:
+                create_user(client, username, host, password)
+                logging.info('created user %s@%s' % (username, host))
+        else:
+            logging.info('user already exists: %s', username)
+
+    return known_hosts
+
+
+def load_databases(client: Connection,
+                   databases: List[Dict[str, Union[List, str]]],
+                   known_hosts: Dict[str, List[str]]):
+    current_databases = set(get_current_databases(client))
+    for database_cfg in databases:
+        name = database_cfg['name']
+        if name in current_databases:
+            logging.info('database already exists: %s', name)
+        else:
+            charset = database_cfg.get('charset', None)
+            collation = database_cfg.get('collation', None)
+
+            create_database(client, name, charset, collation)
+
+            logging.info('created database %s: charset=%r, collation=%r',
+                         name, charset, collation)
+
+        for grant_cfg in database_cfg.get('grants', []):
+            load_grant(client, name, grant_cfg, known_hosts)
+
+
+def main():
+    mysql = get_mysql_client()
+
+    with open(PRELOAD_PATH, 'r') as f:
+        preload = yaml.safe_load(f)
+
+        if 'users' in preload:
+            logger.info('loading users...')
+            known_hosts = load_users(mysql, preload['users'])
+            flush_privileges(mysql)
+        else:
+            logger.info('no users to load')
+            known_hosts = {}
+
+        if 'databases' in preload:
+            logger.info('loading databases...')
+            load_databases(mysql, preload['databases'], known_hosts)
+            flush_privileges(mysql)
+        else:
+            logger.info('no databases to load')
+
+        logger.info('done')
+
+if __name__ == '__main__':
+    main()

--- a/mysql-users-init/preload.yml
+++ b/mysql-users-init/preload.yml
@@ -1,0 +1,2 @@
+users: []
+databases: []

--- a/mysql-users-init/requirements.txt
+++ b/mysql-users-init/requirements.txt
@@ -1,0 +1,5 @@
+dpath
+dotmap
+PyMySQL
+requests
+pyyaml

--- a/mysql-users-init/stack-fix.c
+++ b/mysql-users-init/stack-fix.c
@@ -1,0 +1,30 @@
+// workaround for musl's small stack size causing python segfaults
+// https://github.com/esnme/ultrajson/issues/254#issuecomment-314862445
+
+#include <dlfcn.h>
+
+#include <pthread.h>
+
+typedef int (*func_t)(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg);
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg) {
+	pthread_attr_t local;
+	int used = 0, ret;
+
+	if (!attr) {
+		used = 1;
+		pthread_attr_init(&local);
+		attr = &local;
+	}
+	pthread_attr_setstacksize((void*)attr, 2 * 1024 * 1024); // 2 MB
+
+	func_t orig = (func_t)dlsym(RTLD_NEXT, "pthread_create");
+
+	ret = orig(thread, attr, start_routine, arg);
+
+	if (used) {
+		pthread_attr_destroy(&local);
+	}
+
+	return ret;
+}

--- a/mysql-users-init/start.sh
+++ b/mysql-users-init/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+LD_PRELOAD=/stack-fix.so python mysql_init.py


### PR DESCRIPTION
This adds a new init job that can create users and databases in MySQL,
storing generated credentials in Kubernetes secrets.

Note that this job does not currently handle schema upgrades.
In the future it will either complement or replace the existing
mysql-init job.