### PR TITLE
Support resetting user passwords in mysql-users-init

### DIFF
--- a/mysql-users-init/build.yml
+++ b/mysql-users-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/mysql-users-init
 variants:
   - tag: latest
     aliases:
-      - :1.0.0
-      - :1.0
+      - :1.1.0
+      - :1.1
       - :1


### PR DESCRIPTION
This adds support for resetting mysql passwords when a Kubernetes secret is lost. This should allow clusters to recover persistently stored data in mysql if a k8s cluster (and all the passwords stored in Secrets) is lost.

Also, fixes various string escaping issues.