### PR TITLE
Trim leading slash in k8s_get_service

### DIFF
--- a/keystone/build.yml
+++ b/keystone/build.yml
@@ -1,5 +1,5 @@
 repository: monasca/keystone
 variants:
-  - tag: 1.1.1
+  - tag: 1.1.2
     aliases:
       - :latest

--- a/keystone/k8s_get_service.py
+++ b/keystone/k8s_get_service.py
@@ -43,7 +43,7 @@ class KubernetesAPIException(Exception):
 
 def api_get(endpoint):
     if endpoint.startswith('/'):
-        endpoint = endpoints[:1]
+        endpoint = endpoint[:1]
 
     r = requests.get('{}/{}'.format(API_URL, endpoint),
                      timeout=1000,

--- a/keystone/k8s_get_service.py
+++ b/keystone/k8s_get_service.py
@@ -42,6 +42,9 @@ class KubernetesAPIException(Exception):
 
 
 def api_get(endpoint):
+    if endpoint.startswith('/'):
+        endpoint = endpoints[:1]
+
     r = requests.get('{}/{}'.format(API_URL, endpoint),
                      timeout=1000,
                      headers={'Authorization': 'Bearer {}'.format(TOKEN)},

--- a/keystone/k8s_get_service.py
+++ b/keystone/k8s_get_service.py
@@ -43,7 +43,7 @@ class KubernetesAPIException(Exception):
 
 def api_get(endpoint):
     if endpoint.startswith('/'):
-        endpoint = endpoint[:1]
+        endpoint = endpoint[1:]
 
     r = requests.get('{}/{}'.format(API_URL, endpoint),
                      timeout=1000,


### PR DESCRIPTION
In k8s 1.7 the URL validation is more strict so getting `//api/...`
raises an error. This patches api_get to remove a leading `/`
character in case it gets passed in.