### PR TITLE
Add keystone-shell container

### DIFF
--- a/keystone-shell/Dockerfile
+++ b/keystone-shell/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.6-alpine3.6
+
+# To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
+# `docker build`
+ARG REBUILD=1
+
+COPY requirements.txt stack-fix.c /
+
+RUN apk add --no-cache ca-certificates tini libffi && \
+    apk add --no-cache --virtual build-dep \
+        musl-dev linux-headers git make g++ libffi-dev openssl-dev && \
+    gcc -shared -fPIC /stack-fix.c -o /stack-fix.so && \
+    pip install urllib3 ipaddress ipython ptpython python-openstackclient && \
+    pip install -r /requirements.txt && \
+    rm -rf /root/.cache/pip && \
+    apk del build-dep
+
+COPY keystone_shell_vars.py kubernetes.py ptpython_init.py start.sh /
+COPY keystonerc.sh /root/.keystonerc
+
+ENV ENV="/root/.keystonerc"
+ENTRYPOINT ["sh", "-l", "/start.sh"]
+

--- a/keystone-shell/README.md
+++ b/keystone-shell/README.md
@@ -1,0 +1,106 @@
+keystone-shell
+==============
+
+This image allows you to quickly interact with a keystone environment.
+
+Sources: [keystone-shell][1] &middot; [Dockerfile][2] &middot; [monasca-docker][3]
+
+Tags
+----
+
+Images in this repository are tagged as follows:
+
+ * `latest`: refers to the latest stable point release, e.g. `1.0.0`
+ * `1.0.0`, `1.0`, `1`: standard semver tags
+
+Basic Usage
+-----------
+
+This is mainly intended for use in Kubernetes environments configured using
+[keystone-init][4]. To use, run:
+
+    kubectl run keystone-shell -i -t \
+        --rm=true \
+        --restart Never \
+        --image=monasca/keystone-shell:latest
+
+(pass `-n <NAMESPACE>` as needed if the desired secrets are located elsewhere)
+
+Once the container starts, press enter once to start the shell. Basic usage
+information will be printed to the terminal.
+
+There are three commands available:
+ - `secret <NAME>`: load keystone `OS_` variables from secret in current 
+   namespace `NAME`
+ - `shell [NAME]`: start a Python shell (using ptipython, with highlighting 
+   and autocomplete) with pre-connected Keystone and Kubernetes clients -
+   additional usage information will be printed on startup
+   - if specified, secret with `NAME` will be loaded first (as with 
+     `secret NAME`) and will override existing environment variables
+ - `openstack ...`: the standard openstack client 
+
+Direct Shell
+------------
+
+You can also start a shell directly:
+
+    kubectl run keystone-shell \
+        --rm=true \
+        --restart Never \
+        --image=monasca/keystone-shell:latest \
+        --env="OS_USERNAME=admin" \
+        --env="OS_PASSWORD=secretadmin" \
+        --env="OS_PROJECT_NAME=admin" \
+        --env="OS_PROJECT_DOMAIN_NAME=Default" \
+        --env="OS_USER_DOMAIN_NAME=Default" \
+        --env="OS_AUTH_URL=http://monasca-keystone:35357/" \
+        --env="KEYSTONE_SHELL=true" \
+        --attach -i -t
+
+Note the `KEYSTONE_SHELL` variable. `OS_` variables can also be provided in
+lieu of a secret name (allowing the container to be run in docker rather than
+Kubernetes).
+
+
+Verifying Keystone Connectivity
+-------------------------------
+
+This container can be used as a one-off method to check if a Keystone instance
+is available. To use, try:
+
+    kubectl run keystone-shell \
+        --rm=true \
+        --restart Never \
+        --image=monasca/keystone-shell:latest \
+        --env="KEYSTONE_SECRET=keystone-example-user" \
+        --attach
+        
+Note the absence of the `-i` and `-t` parameters. Note that `KEYSTONE_SECRET`
+must be defined in this scenario.
+
+If Keystone is available and the credentials work, the return code will be
+zero. If Keystone is not available or the credentials are invalid, the return
+code will be 1. Log information should be printed to help narrow down the
+error, or at least as much as Keystone will be willing to divulge about it. 
+
+Configuration
+-------------
+
+| Variable           | Default          | Description                     |
+|--------------------|------------------|---------------------------------|
+| `LOG_LEVEL`        | `INFO` | MySQL server host               |
+| `KEYSTONE_TIMEOUT` | `10`   | MySQL server port               |
+| `KEYSTONE_VERIFY`  | `true` | MySQL user w/ needed privileges |
+| `KEYSTONE_CERT`    | unset  | Password for given user         |
+| `KEYSTONE_SECRET`  | unset  | Secret to auto-load on startup  |
+| `OS_AUTH_URL`            | unset | (**required**)               |
+| `OS_USERNAME`            | unset | keystone username            |
+| `OS_PASSWORD`            | unset | keystone password            |
+| `OS_USER_DOMAIN_NAME`    | unset | keystone user domain name    |
+| `OS_PROJECT_NAME`        | unset | keystone project name        |
+| `OS_PROJECT_DOMAIN_NAME` | unset | keystone project domain name |
+
+[1]: https://github.com/monasca/monasca-docker/blob/master/keystone-shell/
+[2]: https://github.com/monasca/monasca-docker/blob/master/keystone-shell/Dockerfile
+[3]: https://github.com/monasca/monasca-docker/
+[4]: https://github.com/monasca/monasca-docker/blob/master/keystone-init/

--- a/keystone-shell/build.yml
+++ b/keystone-shell/build.yml
@@ -1,0 +1,7 @@
+repository: monasca/keystone-shell
+variants:
+  - tag: latest
+    aliases:
+      - :1.0.0
+      - :1.0
+      - :1

--- a/keystone-shell/keystone_shell_vars.py
+++ b/keystone-shell/keystone_shell_vars.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import base64
+import logging
+import os
+import sys
+
+from typing import Union
+
+from keystoneauth1.identity import Password
+from keystoneauth1.session import Session
+from keystoneclient.discover import Discover
+from requests import HTTPError
+
+from kubernetes import KubernetesAPIClient, KubernetesAPIResponse
+
+NAMESPACE_FILE = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+
+LOG_LEVEL = logging.getLevelName(os.environ.get('LOG_LEVEL', 'INFO'))
+logging.basicConfig(level=LOG_LEVEL,
+                    handlers=(logging.StreamHandler(sys.stderr),))
+
+logger = logging.getLogger(__name__)
+
+KEYSTONE_PASSWORD_ARGS = [
+    'auth_url', 'username', 'password', 'user_id', 'user_domain_id',
+    'user_domain_name', 'project_id', 'project_name', 'project_domain_id',
+    'project_domain_name', 'tenant_id', 'tenant_name', 'domain_id',
+    'domain_name', 'trust_id', 'default_domain_id', 'default_domain_name'
+]
+KEYSTONE_TIMEOUT = int(os.environ.get('KEYSTONE_TIMEOUT', '10'))
+KEYSTONE_VERIFY = os.environ.get('KEYSTONE_VERIFY', 'true') == 'true'
+KEYSTONE_CERT = os.environ.get('KEYSTONE_CERT', None)
+
+_kubernetes_client = None
+
+
+def get_current_namespace() -> str:
+    if 'NAMESPACE' in os.environ:
+        return os.environ['NAMESPACE']
+
+    if os.path.exists(NAMESPACE_FILE):
+        with open(NAMESPACE_FILE, 'r') as f:
+            return f.read()
+
+    logger.warning('Not running in cluster and $NAMESPACE is not set, '
+                   'assuming \'default\'!')
+    return 'default'
+
+
+def get_kubernetes_client() -> KubernetesAPIClient:
+    global _kubernetes_client
+
+    if _kubernetes_client is None:
+        _kubernetes_client = KubernetesAPIClient()
+        _kubernetes_client.load_auto_config()
+
+    return _kubernetes_client
+
+
+def keystone_env_vars():
+    ret = {}
+    for arg in KEYSTONE_PASSWORD_ARGS:
+        name = 'OS_{}'.format(arg.upper())
+        if name in os.environ:
+            ret[name] = os.environ[name]
+
+    return ret
+
+
+def keystone_args_from_env():
+    ret = {}
+    for arg in KEYSTONE_PASSWORD_ARGS:
+        ret[arg] = os.environ.get('OS_{}'.format(arg.upper()))
+
+    return ret
+
+
+def get_keystone_client():
+    auth = Password(**keystone_args_from_env())
+    session = Session(auth=auth,
+                      app_name='keystone-shell',
+                      user_agent='keystone-shell',
+                      timeout=KEYSTONE_TIMEOUT,
+                      verify=KEYSTONE_VERIFY,
+                      cert=KEYSTONE_CERT)
+
+    discover = Discover(session=session)
+    return discover.create_client()
+
+
+def get_kubernetes_secret(name: str,
+                          namespace: str=None) -> Union[KubernetesAPIResponse,
+                                                        None]:
+    """
+    :return: loaded secret dict or None if it does not exist
+    """
+    client = get_kubernetes_client()
+
+    if namespace is None:
+        namespace = get_current_namespace()
+
+    try:
+        return client.get('/api/v1/namespaces/{}/secrets/{}', namespace, name)
+    except HTTPError as e:
+        if e.response.status_code != 404:
+            raise
+
+        return None
+
+
+def main():
+    if len(sys.argv) > 1:
+        secret_name = sys.argv[1]
+
+        if len(sys.argv) > 2:
+            secret_namespace = sys.argv[2]
+        else:
+            secret_namespace = None
+
+        # purge existing keystone vars from the environment
+        for var in keystone_env_vars().keys():
+            print('unset {};'.format(var))
+
+        secret = get_kubernetes_secret(secret_name, secret_namespace)
+        for key, val in secret.data.items():
+            val_bytes = base64.b64decode(val)
+            print('export {}="{}"'.format(key, val_bytes.decode('utf-8')))
+
+        logger.info('now using account from secret %s', secret_name)
+    else:
+        logger.info('no secret name arg provided, will use default environment')
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/keystone-shell/keystonerc.sh
+++ b/keystone-shell/keystonerc.sh
@@ -1,0 +1,11 @@
+secret() {
+    eval "$(python /keystone_shell_vars.py $1)"
+}
+
+shell() {
+    if [ "$#" -ne 1 ]; then
+        eval "$(python /keystone_shell_vars.py $1)"
+    fi
+
+    LD_PRELOAD=/stack-fix.so ptipython -i /ptpython_init.py
+}

--- a/keystone-shell/kubernetes.py
+++ b/keystone-shell/kubernetes.py
@@ -1,0 +1,170 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+import os
+
+import dpath.util
+import requests
+import yaml
+
+from dotmap import DotMap
+
+CACERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
+KUBE_CONFIG_PATH = os.environ.get('KUBECONFIG', '~/.kube/config')
+
+KUBERNETES_SERVICE_HOST = os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default')
+KUBERNETES_SERVICE_PORT = os.environ.get('KUBERNETES_SERVICE_PORT', '443')
+KUBERNETES_API_URL = "https://{}:{}".format(KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT)
+
+DEFAULT_TIMEOUT = 10
+
+
+def load_current_kube_credentials():
+    with open(os.path.expanduser(KUBE_CONFIG_PATH), 'r') as f:
+        config = DotMap(yaml.safe_load(f))
+
+        ctx_name = config['current-context']
+        ctx = next(c for c in config.contexts if c.name == ctx_name)
+        cluster = next(c for c in config.clusters if c.name == ctx.context.cluster).cluster
+
+        if 'certificate-authority' in cluster:
+            ca_cert = cluster['certificate-authority']
+        else:
+            ca_cert = None
+
+        if ctx.context.user:
+            user = next(u for u in config.users if u.name == ctx.context.user).user
+            return cluster.server, ca_cert, (user['client-certificate'], user['client-key'])
+        else:
+            return cluster.server, ca_cert, None
+
+
+class KubernetesAPIError(Exception):
+    pass
+
+
+class KubernetesAPIResponse(DotMap):
+
+    def __init__(self, response, decoded=None):
+        super(KubernetesAPIResponse, self).__init__(decoded, _dynamic=False)
+        self.response = response
+
+    def get(self, glob, separator="/"):
+        return dpath.util.get(self, glob, separator)
+
+    def search(self, glob, yielded=False, separator="/", afilter=None, dirs=True):
+        return dpath.util.search(self, glob, yielded, separator, afilter, dirs)
+
+    def set(self, glob, value):
+        return dpath.util.set(self, glob, value)
+
+    def new(self, path, value):
+        return dpath.util.new(self, path, value)
+
+    @property
+    def status_code(self):
+        return self.response.status_code
+
+
+class KubernetesAPIClient(object):
+    def __init__(self, verify=True):
+        self.session = requests.Session()
+        self.session.verify = verify
+        self.api_url = None
+
+    def load_cluster_config(self):
+        self.session.verify = CACERT_PATH
+
+        # requests will purge request Content-Type headers if we hit a
+        # redirect, so try to avoid running into one because of an extra /
+        self.api_url = KUBERNETES_API_URL.rstrip('/')
+
+        with open(TOKEN_PATH, 'r') as f:
+            token = f.read()
+            self.session.headers.update({
+                'Authorization': 'Bearer {}'.format(token)
+            })
+
+    def load_kube_config(self):
+        server, ca_cert, cert = load_current_kube_credentials()
+        self.api_url = server.rstrip('/')
+        self.session.cert = cert
+        self.session.verify = ca_cert
+
+        if self.api_url.endswith('/'):
+            self.api_url = self.api_url.rstrip('/')
+
+    def load_auto_config(self):
+        if os.path.exists(os.path.expanduser(KUBE_CONFIG_PATH)):
+            self.load_kube_config()
+        elif os.path.exists(TOKEN_PATH):
+            self.load_cluster_config()
+        else:
+            raise KubernetesAPIError('No supported API configuration found!')
+
+    def request(self, method, path, *args, **kwargs):
+        raise_for_status = kwargs.pop('raise_for_status', True)
+        timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT)
+
+        if args:
+            path = path.format(*args)
+
+        slash = '' if path.startswith('/') else '/'
+        res = self.session.request(
+            method,
+            '{}{}{}'.format(self.api_url, slash, path),
+            timeout=timeout,
+            **kwargs)
+
+        if raise_for_status:
+            res.raise_for_status()
+
+        return KubernetesAPIResponse(res, res.json())
+
+    def get(self, path, *args, **kwargs):
+        kwargs.setdefault('allow_redirects', True)
+        return self.request('GET', path, *args, **kwargs)
+
+    def post(self, path, *args, **kwargs):
+        return self.request('POST', path, *args, **kwargs)
+
+    def delete(self, path, *args, **kwargs):
+        return self.request('DELETE', path, *args, **kwargs)
+
+    def patch(self, path, *args, **kwargs):
+        return self.request('PATCH', path, *args, **kwargs)
+
+    def json_patch(self, ops, path, *args, **kwargs):
+        if kwargs.get('allow_redirects') is True:
+            raise ValueError('Patch is not compatible with redirects!')
+
+        headers = kwargs.pop('headers', None)
+        if headers:
+            headers = headers.copy()
+        else:
+            headers = {}
+
+        headers['Content-Type'] = 'application/json-patch+json'
+        resp = self.patch(path,
+                          data=json.dumps(ops), headers=headers,
+                          allow_redirects=False,
+                          *args, **kwargs)
+        if 300 <= resp.status_code < 400:
+            raise KubernetesAPIError('Encountered a redirect while sending a '
+                                     'PATCH, failing!')
+
+        return resp

--- a/keystone-shell/ptpython_init.py
+++ b/keystone-shell/ptpython_init.py
@@ -1,0 +1,13 @@
+import keystone_shell_vars
+
+keystone = keystone_shell_vars.get_keystone_client()
+ks = keystone
+
+kubernetes = keystone_shell_vars.get_kubernetes_client()
+k8s = kubernetes
+
+print('--------------------------------------')
+print('Pre-defined variables:')
+print(' - keystone (ks): keystone client')
+print(' - kubernetes (k8s): kubernetes client')
+print('--------------------------------------')

--- a/keystone-shell/requirements.txt
+++ b/keystone-shell/requirements.txt
@@ -1,0 +1,6 @@
+dpath
+dotmap
+pbr>=1.8
+keystoneauth1
+python-keystoneclient>=3.8.0 # Apache-2.0
+requests

--- a/keystone-shell/stack-fix.c
+++ b/keystone-shell/stack-fix.c
@@ -1,0 +1,30 @@
+// workaround for musl's small stack size causing python segfaults
+// https://github.com/esnme/ultrajson/issues/254#issuecomment-314862445
+
+#include <dlfcn.h>
+
+#include <pthread.h>
+
+typedef int (*func_t)(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg);
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg) {
+	pthread_attr_t local;
+	int used = 0, ret;
+
+	if (!attr) {
+		used = 1;
+		pthread_attr_init(&local);
+		attr = &local;
+	}
+	pthread_attr_setstacksize((void*)attr, 2 * 1024 * 1024); // 2 MB
+
+	func_t orig = (func_t)dlsym(RTLD_NEXT, "pthread_create");
+
+	ret = orig(thread, attr, start_routine, arg);
+
+	if (used) {
+		pthread_attr_destroy(&local);
+	}
+
+	return ret;
+}

--- a/keystone-shell/start.sh
+++ b/keystone-shell/start.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+source /root/.keystonerc
+
+if [ -t 1 ]; then
+    echo "Press enter to continue..."
+    read
+
+    echo ""
+    echo "Usage:"
+    echo "  secret    <secret name>  - load a different secret"
+    echo "  shell     [secret name]  - open a python shell with keystone and k8s clients"
+    echo "  openstack [...]          - use the openstack client"
+    echo ""
+
+    if [ -n "$KEYSTONE_SECRET" ]; then
+        secret "$KEYSTONE_SECRET"
+    fi
+
+    if [ -n "$KEYSTONE_SHELL" ]; then
+        shell
+    else
+        sh -l
+    fi
+else
+    if [ -n "$KEYSTONE_SECRET" ]; then
+        secret "$KEYSTONE_SECRET"
+        if [ $? -ne 0 ]; then
+            echo "Could not find secret: $KEYSTONE_SECRET"
+            sleep 5
+            exit 1
+        fi
+
+        python -c "import keystone_shell_vars; keystone_shell_vars.get_keystone_client()"
+        if [ $? -eq 0 ]; then
+            echo "Keystone connection successful!"
+            sleep 1
+            exit 0
+        else
+            echo "Could not connect to keystone!"
+            sleep 5
+            exit 1
+        fi
+    else
+        echo "No \$KEYSTONE_SECRET defined, nothing to do!"
+        echo "Either run interactively (-i -t) or specify \$KEYSTONE_SECRET"
+        echo "to verify connection."
+        sleep 5
+        exit 0
+    fi
+fi


### PR DESCRIPTION
The keystone-shell is a container to help debug keystone instances in
Kubernetes. It provides a ptipython-based shell with highlighting,
autocomplete, and access to the Keystone and Kubernetes APIs, along
with an OpenStack client and utility function to read and swap between
credentials from secrets (in any namespace) at runtime.