### PR TITLE
Use yarn v0.27

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -23,7 +23,7 @@ run mkdir -p /var/lib/grafana && \
   git fetch origin $GRAFANA_BRANCH && \
   git reset --hard FETCH_HEAD && \
   go run build.go setup && go run build.go build && \
-  npm install -g yarn && yarn && \
+  npm install -g yarn@0.27 && yarn && \
   ./node_modules/.bin/grunt build --force && \
   cp -r ./conf /var/lib/grafana/conf && \
   cp -r ./public_gen /var/lib/grafana/public && \


### PR DESCRIPTION
"yarn" which is newer than v0.28 doesn't work with nodejs newer than
4.x. This patch force to use yarn v0.27.