### PR TITLE
Set restart policy for monasca-collector

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
 
   agent-collector:
     image: monasca/agent-collector:${MON_AGENT_COLLECTOR_VERSION}
+    restart: on-failure
     environment:
       AGENT_HOSTNAME: "docker-host"
       FORWARDER_URL: "http://agent-forwarder:17123"


### PR DESCRIPTION
By design the Monasca Agent Collector exits every 24 hours because
there have been problems with massive memory growth. Set restart
policy to on-failure so it will auto restart in this case.