### PR TITLE
Make Grafana admin user configurable

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -11,13 +11,16 @@ arg MONASCA_APP_BRANCH=master
 # `docker build`
 arg REBUILD=1
 
-env GOPATH=/go GOBIN=/go/bin
+env GOPATH=/go GOBIN=/go/bin \
+    GRAFANA_ADMIN_USER=admin \
+    GRAFANA_ADMIN_PASSWORD=admin
 
 run mkdir -p /var/lib/grafana && \
   mkdir -p $GOPATH/src/github.com/grafana/grafana && \
   cd $GOPATH/src/github.com/grafana/grafana/ && \
   apk add --no-cache --virtual build-dep \
-    nodejs go git musl-dev python make g++ && \
+    nodejs go git musl-dev make g++ && \
+  apk add --no-cache python py-jinja2 && \
   git init && \
   git remote add origin $GRAFANA_REPO && \
   git fetch origin $GRAFANA_BRANCH && \
@@ -51,10 +54,12 @@ run mkdir -p /var/lib/grafana && \
   rm -f /go/bin/govendor && \
   rm -rf /go/pkg
 
-copy grafana.ini /etc/grafana/grafana.ini
+copy grafana.ini.j2 /etc/grafana/grafana.ini.j2
+copy template.py start.sh /
+run chmod +x /template.py /start.sh
 expose 3000
 
 healthcheck --interval=10s --timeout=5s \
   cmd wget -q http://localhost:3000 -O - > /dev/null
 
-cmd ["/go/bin/grafana-server", "-config", "/etc/grafana/grafana.ini", "-homepath", "/var/lib/grafana"]
+cmd ["/start.sh"]

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -40,6 +40,11 @@ Note that in the [Kubernetes environment][6], the URL should instead be
 Configuration
 -------------
 
+| Variable                 | Default | Description                     |
+|--------------------------|---------|---------------------------------|
+| `GRAFANA_ADMIN_USER`     | `admin` | Grafana admin user name         |
+| `GRAFANA_ADMIN_PASSWORD` | `admin` | Grafana admin user password     |
+
 Grafana can be configured using [environment variables][7], though a
 configuration file can also be mounted into the image at
 `/etc/grafana/grafana.ini`. Plugins should be placed in

--- a/grafana/grafana.ini.j2
+++ b/grafana/grafana.ini.j2
@@ -116,10 +116,10 @@ check_for_updates = true
 #################################### Security ####################################
 [security]
 # default admin user, created on startup
-;admin_user = admin
+admin_user = {{ GRAFANA_ADMIN_USER }}
 
 # default admin password, can be changed before first start of grafana,  or in profile settings
-;admin_password = admin
+admin_password = {{ GRAFANA_ADMIN_PASSWORD }}
 
 # used for signing
 ;secret_key = SW2YcwTIb9zpOOhoPsMm

--- a/grafana/start.sh
+++ b/grafana/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python /template.py /etc/grafana/grafana.ini.j2 /etc/grafana/grafana.ini
+/go/bin/grafana-server -config /etc/grafana/grafana.ini -homepath /var/lib/grafana

--- a/grafana/template.py
+++ b/grafana/template.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function
+
+import os
+import sys
+
+from jinja2 import Template
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('Usage: {} [input] [output]'.format(sys.argv[0]))
+        sys.exit(1)
+
+    in_path = sys.argv[1]
+    out_path = sys.argv[2]
+
+    with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
+        t = Template(in_file.read())
+        out_file.write(t.render(os.environ))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The initialization file for grafana was not configurable by using
enrironmental variables during the startup of the container. This commit
makes it possible to configure Grafana admin user name and password of
the file.