### PR TITLE
Use monasca/python for monasca/agent-base

### DIFF
--- a/monasca-agent-base/Dockerfile
+++ b/monasca-agent-base/Dockerfile
@@ -1,9 +1,12 @@
-FROM alpine:3.5
+ARG TIMESTAMP_SLUG
+# note(kornicameiter) running monasca-agent with Python3 is not possible
+# at the moment, enforce Python2 variant of monasca/python
+FROM monasca/python:2-${TIMESTAMP_SLUG}
 
 ARG AGENT_REPO=https://git.openstack.org/openstack/monasca-agent
-ARG AGENT_BRANCH="master"
-ARG UPPER_CONSTRAINTS=https://raw.githubusercontent.com/openstack/requirements/master/upper-constraints.txt
-ARG AGENT_USER="mon-agent"
+ARG AGENT_BRANCH=master
+ARG CONSTRAINTS_BRANCH=master
+ARG AGENT_USER=mon-agent
 
 # To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
 # `docker build`
@@ -20,23 +23,10 @@ ENV CONFIG_TEMPLATE=true \
   LOG_LEVEL=WARN \
   HOSTNAME_FROM_KUBERNETES=false
 
-RUN apk add --no-cache \
-    python py2-pip py2-jinja2 libxml2 py2-psutil && \
-  apk add --no-cache --virtual build-dep \
-     git python-dev make g++ linux-headers libxml2-dev libxslt-dev && \
-  mkdir /monasca-agent && cd /monasca-agent && \
-  git init && \
-  git remote add origin $AGENT_REPO && \
-  git fetch origin $AGENT_BRANCH && \
-  git reset --hard FETCH_HEAD && \
-  pip install docker-py prometheus_client && \
-  cd /monasca-agent && \
-  pip install -r requirements.txt -c "$UPPER_CONSTRAINTS" && \
-  python setup.py install && \
-  cd / && \
-  rm -rf /monasca-agent && \
-  rm -rf /root/.cache/pip && \
-  apk del build-dep
+COPY apk_install.sh /apk.sh
+RUN /build.sh -r ${AGENT_REPO} -b ${AGENT_BRANCH} -q ${CONSTRAINTS_BRANCH}  \
+  -d "Jinja2 prometheus_client docker-py" && \
+  rm -rf /build.sh
 
 COPY agent.yaml.j2 /etc/monasca/agent/agent.yaml.j2
 COPY template.py kubernetes_get_host.py /

--- a/monasca-agent-base/apk_install.sh
+++ b/monasca-agent-base/apk_install.sh
@@ -1,0 +1,4 @@
+install_apk_deps() {
+  apk add --no-cache libxml2 py2-psutil
+  apk add --no-cache --virtual build-dep git make g++ linux-headers libxml2-dev libxslt-dev
+}

--- a/monasca-agent-base/build.yml
+++ b/monasca-agent-base/build.yml
@@ -4,4 +4,4 @@ variants:
     aliases:
       - :master-{date}-{time}
     args:
-      TIMESTAMP_SLUG: 20170901-210328
+      TIMESTAMP_SLUG: 20170809-155207

--- a/monasca-agent-base/build.yml
+++ b/monasca-agent-base/build.yml
@@ -3,3 +3,5 @@ variants:
   - tag: master
     aliases:
       - :master-{date}-{time}
+    args:
+      TIMESTAMP_SLUG: 20170809-155207

--- a/monasca-agent-base/build.yml
+++ b/monasca-agent-base/build.yml
@@ -4,4 +4,4 @@ variants:
     aliases:
       - :master-{date}-{time}
     args:
-      TIMESTAMP_SLUG: 20170809-155207
+      TIMESTAMP_SLUG: 20170901-210328


### PR DESCRIPTION
monasca/python provides a foundation for the Python
monasca components and several features & fixes that
concern and affects all Python applications.

!push monasca-agent-base