### PR TITLE
Use monasca/python for monasca/client

### DIFF
--- a/monasca-client/Dockerfile
+++ b/monasca-client/Dockerfile
@@ -1,28 +1,17 @@
-FROM alpine:3.5
+ARG PYTHON_VERSION
+ARG TIMESTAMP_SLUG
+FROM monasca/python:${PYTHON_VERSION}-${TIMESTAMP_SLUG}
 
 ARG CLIENT_REPO=https://git.openstack.org/openstack/python-monascaclient
-ARG CLIENT_BRANCH="master"
-ARG UPPER_CONSTRAINTS=https://raw.githubusercontent.com/openstack/requirements/master/upper-constraints.txt
+ARG CLIENT_BRANCH=master
+ARG CONSTRAINTS_BRANCH=master
 
 # To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
 # `docker build`
 ARG REBUILD=1
 
-RUN set -x && \
-  apk add --no-cache python py2-pip git && \
-  apk add --no-cache --virtual build-dep \
-     git python-dev make g++ linux-headers libxml2-dev libxslt-dev && \
-  mkdir /python-monascaclient && cd /python-monascaclient && \
-  git init && \
-  git remote add origin $CLIENT_REPO && \
-  git fetch origin $CLIENT_BRANCH && \
-  git reset --hard FETCH_HEAD && \
-  pip install -r requirements.txt -c "$UPPER_CONSTRAINTS" && \
-  python setup.py install && \
-  cd / && \
-  rm -rf /python-monascaclient && \
-  rm -rf /root/.cache/pip && \
-  apk del build-dep
-
+RUN apk add --no-cache --virtual build-dep libxml2-dev libxslt-dev && \
+  /build.sh -r ${CLIENT_REPO} -b ${CLIENT_BRANCH} -q ${CONSTRAINTS_BRANCH} && \
+  monasca --version
 
 CMD ["sh"]

--- a/monasca-client/build.yml
+++ b/monasca-client/build.yml
@@ -1,12 +1,30 @@
 repository: monasca/client
 variants:
-  - tag: latest
+  - tag: 1.7.0
     aliases:
-      - :1.6.0
+      - :latest
+      - :1.7
+      - :1
+    args:
+      CLIENT_BRANCH: 1.7.0
+      PYTHON_VERSION: '2'
+      TIMESTAMP_SLUG: 20170809-155207
+      CONSTRAINTS_BRANCH: master
+
+  - tag: 1.6.0
+    aliases:
+      - :1.6
     args:
       CLIENT_BRANCH: 1.6.0
+      PYTHON_VERSION: '2'
+      TIMESTAMP_SLUG: 20170809-155207
+      CONSTRAINTS_BRANCH: master
+
   - tag: master
     aliases:
       - :master-{date}-{time}
     args:
       CLIENT_BRANCH: master
+      PYTHON_VERSION: '2'
+      TIMESTAMP_SLUG: 20170809-155207
+      CONSTRAINTS_BRANCH: master


### PR DESCRIPTION
monasca/python provides a foundation for the Python
monasca components and several features & fixes that
concern and affects all Python applications.

!push monasca-client