### PR TITLE
Fix some linter warnings, part 4.2

### DIFF
--- a/monasca-log-persister/kafka_wait_for_topics.py
+++ b/monasca-log-persister/kafka_wait_for_topics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #

--- a/monasca-log-persister/start.sh
+++ b/monasca-log-persister/start.sh
@@ -7,7 +7,7 @@ if [ -n "$KAFKA_WAIT_FOR_TOPICS" ]; then
   echo "Waiting for Kafka topics to become available..."
   success="false"
 
-  for i in $(seq $KAFKA_WAIT_RETRIES); do
+  for i in $(seq "$KAFKA_WAIT_RETRIES"); do
     python /kafka_wait_for_topics.py
     if [ $? -eq 0 ]; then
       success="true"

--- a/monasca-log-persister/template.py
+++ b/monasca-log-persister/template.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
@@ -31,8 +32,8 @@ def main():
     out_path = sys.argv[2]
 
     with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
-        t = Template(in_file.read())
-        out_file.write(t.render(os.environ))
+        tmle = Template(in_file.read())
+        out_file.write(tmle.render(os.environ))
 
 if __name__ == '__main__':
     main()

--- a/monasca-log-transformer/kafka_wait_for_topics.py
+++ b/monasca-log-transformer/kafka_wait_for_topics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #

--- a/monasca-log-transformer/start.sh
+++ b/monasca-log-transformer/start.sh
@@ -7,7 +7,7 @@ if [ -n "$KAFKA_WAIT_FOR_TOPICS" ]; then
   echo "Waiting for Kafka topics to become available..."
   success="false"
 
-  for i in $(seq $KAFKA_WAIT_RETRIES); do
+  for i in $(seq "$KAFKA_WAIT_RETRIES"); do
     python /kafka_wait_for_topics.py
     if [ $? -eq 0 ]; then
       success="true"

--- a/monasca-log-transformer/template.py
+++ b/monasca-log-transformer/template.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
@@ -31,8 +32,8 @@ def main():
     out_path = sys.argv[2]
 
     with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
-        t = Template(in_file.read())
-        out_file.write(t.render(os.environ))
+        tmle = Template(in_file.read())
+        out_file.write(tmle.render(os.environ))
 
 if __name__ == '__main__':
     main()

--- a/monasca-notification/kafka_wait_for_topics.py
+++ b/monasca-notification/kafka_wait_for_topics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #

--- a/monasca-notification/start.sh
+++ b/monasca-notification/start.sh
@@ -9,7 +9,7 @@ KAFKA_WAIT_DELAY=${KAFKA_WAIT_DELAY:-"5"}
 
 echo "Waiting for MySQL to become available..."
 success="false"
-for i in $(seq $MYSQL_WAIT_RETRIES); do
+for i in $(seq "$MYSQL_WAIT_RETRIES"); do
   mysqladmin status \
       --host="$MYSQL_DB_HOST" \
       --port="$MYSQL_DB_PORT" \
@@ -36,7 +36,7 @@ if [ -n "$KAFKA_WAIT_FOR_TOPICS" ]; then
   echo "Waiting for Kafka topics to become available..."
   success="false"
 
-  for i in $(seq $KAFKA_WAIT_RETRIES); do
+  for i in $(seq "$KAFKA_WAIT_RETRIES"); do
     python /kafka_wait_for_topics.py
     if [ $? -eq 0 ]; then
       success="true"

--- a/monasca-notification/template.py
+++ b/monasca-notification/template.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
@@ -30,11 +31,11 @@ def main():
     out_path = sys.argv[2]
 
     with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
-        t = Template(in_file.read(),
-                     keep_trailing_newline=True,
-                     lstrip_blocks=True,
-                     trim_blocks=True)
-        out_file.write(t.render(os.environ))
+        tmle = Template(in_file.read(),
+                        keep_trailing_newline=True,
+                        lstrip_blocks=True,
+                        trim_blocks=True)
+        out_file.write(tmle.render(os.environ))
 
 if __name__ == '__main__':
     main()

--- a/monasca-persister-python/kafka_wait_for_topics.py
+++ b/monasca-persister-python/kafka_wait_for_topics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #

--- a/monasca-persister-python/start.sh
+++ b/monasca-persister-python/start.sh
@@ -9,7 +9,7 @@ if [ -n "$KAFKA_WAIT_FOR_TOPICS" ]; then
   echo "Waiting for Kafka topics to become available..."
   success="false"
 
-  for i in $(seq $KAFKA_WAIT_RETRIES); do
+  for i in $(seq "$KAFKA_WAIT_RETRIES"); do
     python /kafka_wait_for_topics.py
     if [ $? -eq 0 ]; then
       success="true"

--- a/monasca-persister-python/template.py
+++ b/monasca-persister-python/template.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
@@ -30,8 +31,8 @@ def main():
     out_path = sys.argv[2]
 
     with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
-        t = Template(in_file.read())
-        out_file.write(t.render(os.environ))
+        tmle = Template(in_file.read())
+        out_file.write(tmle.render(os.environ))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
PR #204 fails because changes are made in more than 5 modules.
This PR reproduces changes made in PR #204 to 4 modules: 
- monasca-notification
- monasca-log-persister
- monasca-log-transformer
- monasca-persister-python
 The remaining modules remain in the original PR (part 4.1)