### PR TITLE
Configure keystone && fix alarms to work with new python-monascaclient

### DIFF
--- a/grafana/start.sh
+++ b/grafana/start.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+if [ -n $GF_DATABASE_PORT ]; then
+  export GF_DATABASE_HOST=$GF_DATABASE_HOST":"$GF_DATABASE_PORT
+fi
+
 python /template.py /etc/grafana/grafana.ini.j2 /etc/grafana/grafana.ini
 /go/bin/grafana-server -config /etc/grafana/grafana.ini -homepath /var/lib/grafana

--- a/grafana/start.sh
+++ b/grafana/start.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-if [ -n $GF_DATABASE_PORT ]; then
-  export GF_DATABASE_HOST=$GF_DATABASE_HOST":"$GF_DATABASE_PORT
-fi
-
 python /template.py /etc/grafana/grafana.ini.j2 /etc/grafana/grafana.ini
 /go/bin/grafana-server -config /etc/grafana/grafana.ini -homepath /var/lib/grafana

--- a/monasca-agent-base/Dockerfile
+++ b/monasca-agent-base/Dockerfile
@@ -13,12 +13,7 @@ ARG AGENT_USER=mon-agent
 ARG REBUILD=1
 
 ENV CONFIG_TEMPLATE=true \
-  OS_AUTH_URL=http://keystone:35357/v3/ \
-  OS_USERNAME=monasca-agent \
-  OS_PASSWORD=password \
-  OS_USER_DOMAIN_NAME=Default \
-  OS_PROJECT_NAME=mini-mon \
-  OS_PROJECT_DOMAIN_NAME=Default \
+  KEYSTONE_DEFAULTS_ENABLED=true \
   MONASCA_URL=http://monasca:8070/v2.0 \
   LOG_LEVEL=WARN \
   HOSTNAME_FROM_KUBERNETES=false

--- a/monasca-agent-collector/README.md
+++ b/monasca-agent-collector/README.md
@@ -70,18 +70,19 @@ variables must be set instead, see below for details.
 Configuration
 -------------
 
-| Variable                 | Default          | Description                         |
-|--------------------------|------------------|-------------------------------------|
-| `LOG_LEVEL`              | `WARN`           | Python logging level                |
-| `OS_AUTH_URL`            | `http://keystone:35357/v3/` | Versioned Keystone URL   |
-| `OS_USERNAME`            | `monasca-agent`  | Agent Keystone username             |
-| `OS_PASSWORD`            | `password`       | Agent Keystone password             |
-| `OS_USER_DOMAIN_NAME`    | `Default`        | Agent Keystone user domain          |
-| `OS_PROJECT_NAME`        | `mini-mon`       | Agent Keystone project name         |
-| `OS_PROJECT_DOMAIN_NAME` | `Default`        | Agent Keystone project domain       |
-| `MONASCA_URL`            | `http://monasca:8070/v2.0` | Versioned Monasca API URL |
-| `HOSTNAME_FROM_KUBERNETES` | `false` | If true, determine node hostname from Kubernetes  |
-| `FORWARDER_URL`            | `http://localhost:17123` | Monasca Agent Collector URL |
+| Variable                    | Default          | Description                         |
+|-----------------------------|------------------|-------------------------------------|
+| `LOG_LEVEL`                 | `WARN`           | Python logging level                |
+| `KEYSTONE_DEFAULTS_ENABLED` | `true`           | Sets all OS defaults                |
+| `OS_AUTH_URL`               | `http://keystone:35357/v3/` | Versioned Keystone URL   |
+| `OS_USERNAME`               | `monasca-agent`  | Agent Keystone username             |
+| `OS_PASSWORD`               | `password`       | Agent Keystone password             |
+| `OS_USER_DOMAIN_NAME`       | `Default`        | Agent Keystone user domain          |
+| `OS_PROJECT_NAME`           | `mini-mon`       | Agent Keystone project name         |
+| `OS_PROJECT_DOMAIN_NAME`    | `Default`        | Agent Keystone project domain       |
+| `MONASCA_URL`               | `http://monasca:8070/v2.0` | Versioned Monasca API URL |
+| `HOSTNAME_FROM_KUBERNETES`  | `false` | If true, determine node hostname from Kubernetes  |
+| `FORWARDER_URL`             | `http://localhost:17123` | Monasca Agent Collector URL |
 
 Note that additional variables can be specified as well, see the
 [config template][8] for a definitive list.

--- a/monasca-agent-collector/start.sh
+++ b/monasca-agent-collector/start.sh
@@ -9,6 +9,15 @@ USER_PLUGINS="/plugins.d"
 AGENT_CONF="/etc/monasca/agent"
 AGENT_PLUGINS="$AGENT_CONF/conf.d"
 
+if [ "$KEYSTONE_DEFAULTS_ENABLED" == "true" ]; then
+  export OS_AUTH_URL=${OS_AUTH_URL:-"http://keystone:35357/v3/"}
+  export OS_USERNAME=${OS_USERNAME:-"monasca-agent"}
+  export OS_PASSWORD=${OS_PASSWORD:-"password"}
+  export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-"Default"}
+  export OS_PROJECT_NAME=${OS_PROJECT_NAME:-"mini-mon"}
+  export OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-"Default"}
+fi
+
 mkdir -p "$AGENT_PLUGINS"
 
 template () {

--- a/monasca-agent-forwarder/README.md
+++ b/monasca-agent-forwarder/README.md
@@ -35,18 +35,19 @@ can be minimally run like so:
 Configuration
 -------------
 
-| Variable                 | Default          | Description                         |
-|--------------------------|------------------|-------------------------------------|
-| `LOG_LEVEL`              | `WARN`           | Python logging level                |
-| `OS_AUTH_URL`            | `http://keystone:35357/v3/` | Versioned Keystone URL   |
-| `OS_USERNAME`            | `monasca-agent`  | Agent Keystone username             |
-| `OS_PASSWORD`            | `password`       | Agent Keystone password             |
-| `OS_USER_DOMAIN_NAME`    | `Default`        | Agent Keystone user domain          |
-| `OS_PROJECT_NAME`        | `mini-mon`       | Agent Keystone project name         |
-| `OS_PROJECT_DOMAIN_NAME` | `Default`        | Agent Keystone project domain       |
-| `MONASCA_URL`            | `http://monasca:8070/v2.0` | Versioned Monasca API URL |
-| `HOSTNAME_FROM_KUBERNETES` | `false` | If true, determine node hostname from Kubernetes  |
-| 'NON_LOCAL_TRAFFIC'        | `false` | If true, forwarder listens on all addresses |
+| Variable                    | Default          | Description                         |
+|-----------------------------|------------------|-------------------------------------|
+| `LOG_LEVEL`                 | `WARN`           | Python logging level                |
+| `KEYSTONE_DEFAULTS_ENABLED` | `true`           | Sets all OS defaults                |
+| `OS_AUTH_URL`               | `http://keystone:35357/v3/` | Versioned Keystone URL   |
+| `OS_USERNAME`               | `monasca-agent`  | Agent Keystone username             |
+| `OS_PASSWORD`               | `password`       | Agent Keystone password             |
+| `OS_USER_DOMAIN_NAME`       | `Default`        | Agent Keystone user domain          |
+| `OS_PROJECT_NAME`           | `mini-mon`       | Agent Keystone project name         |
+| `OS_PROJECT_DOMAIN_NAME`    | `Default`        | Agent Keystone project domain       |
+| `MONASCA_URL`               | `http://monasca:8070/v2.0` | Versioned Monasca API URL |
+| `HOSTNAME_FROM_KUBERNETES`  | `false` | If true, determine node hostname from Kubernetes  |
+| `NON_LOCAL_TRAFFIC`         | `false` | If true, forwarder listens on all addresses |
 
 Note that additional variables can be specified as well, see the
 [config template][8] for a definitive list.

--- a/monasca-agent-forwarder/start.sh
+++ b/monasca-agent-forwarder/start.sh
@@ -5,6 +5,15 @@ set -x
 
 AGENT_CONF="/etc/monasca/agent"
 
+if [ "$KEYSTONE_DEFAULTS_ENABLED" == "true" ]; then
+  export OS_AUTH_URL=${OS_AUTH_URL:-"http://keystone:35357/v3/"}
+  export OS_USERNAME=${OS_USERNAME:-"monasca-agent"}
+  export OS_PASSWORD=${OS_PASSWORD:-"password"}
+  export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-"Default"}
+  export OS_PROJECT_NAME=${OS_PROJECT_NAME:-"mini-mon"}
+  export OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-"Default"}
+fi
+
 template () {
   if [ "$CONFIG_TEMPLATE" = "true" ]; then
     python /template.py "$1" "$2"

--- a/monasca-alarms/Dockerfile
+++ b/monasca-alarms/Dockerfile
@@ -5,12 +5,7 @@ FROM alpine:3.5
 ARG REBUILD=1
 
 ENV MONASCA_WAIT_FOR_API=true \
-  OS_PASSWORD=password \
-  OS_PROJECT_DOMAIN_NAME=Default \
-  OS_AUTH_URL=http://keystone:35357/v3/ \
-  OS_PROJECT_NAME=mini-mon \
-  OS_USERNAME=mini-mon \
-  OS_USER_DOMAIN_NAME=Default
+  KEYSTONE_DEFAULTS_ENABLED=false
 
 RUN apk add --no-cache \
     python py2-pip py2-netaddr py2-yaml py2-jinja2 && \

--- a/monasca-alarms/README.md
+++ b/monasca-alarms/README.md
@@ -26,15 +26,16 @@ docker run -it monasca/alarms:latest
 Configuration
 -------------
 
-| Variable                 | Default                      | Description                      |
-|--------------------------|------------------------------|----------------------------------|
-| `MONASCA_WAIT_FOR_API`   | `true`                       | Ensure Monasca API is available  |
-| `OS_PASSWORD`            | `password`                   | Password for Keystone User       |
-| `OS_PROJECT_DOMAIN_NAME` | `Default`                    | User Project Domain Name         |
-| `OS_AUTH_URL`            | `http://keystone:35357/v3/`  | Keystone URL                     |
-| `OS_PROJECT_NAME`        | `mini-mon`                   | User Project Name                |
-| `OS_USERNAME`            | `mini-mon`                   | Keystone User Name               |
-| `OS_USER_DOMAIN_NAME`    | `Default`                    | Keystone User Domain Name        |
+| Variable                    | Default                      | Description                      |
+|-----------------------------|------------------------------|----------------------------------|
+| `MONASCA_WAIT_FOR_API`      | `true`                       | Ensure Monasca API is available  |
+| `KEYSTONE_DEFAULTS_ENABLED` | `true`                       | Sets all OS defaults                |
+| `OS_PASSWORD`               | `password`                   | Password for Keystone User       |
+| `OS_PROJECT_DOMAIN_NAME`    | `Default`                    | User Project Domain Name         |
+| `OS_AUTH_URL`               | `http://keystone:35357/v3/`  | Keystone URL                     |
+| `OS_PROJECT_NAME`           | `mini-mon`                   | User Project Name                |
+| `OS_USERNAME`               | `mini-mon`                   | Keystone User Name               |
+| `OS_USER_DOMAIN_NAME`       | `Default`                    | Keystone User Domain Name        |
 
 The yaml file describing the Notifications and Alarm Definitions is available
 [in the repository][2].

--- a/monasca-alarms/start.sh
+++ b/monasca-alarms/start.sh
@@ -4,6 +4,15 @@
 MONASCA_API_WAIT_RETRIES=${MONASCA_API_WAIT_RETRIES:-"24"}
 MONASCA_API_WAIT_DELAY=${MONASCA_API_WAIT_DELAY:-"5"}
 
+if [ "$KEYSTONE_DEFAULTS_ENABLED" == "true" ]; then
+  export OS_AUTH_URL=${OS_AUTH_URL:-"http://keystone:35357/v3/"}
+  export OS_USERNAME=${OS_USERNAME:-"monasca-agent"}
+  export OS_PASSWORD=${OS_PASSWORD:-"password"}
+  export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-"Default"}
+  export OS_PROJECT_NAME=${OS_PROJECT_NAME:-"mini-mon"}
+  export OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-"Default"}
+fi
+
 if [ -n "$MONASCA_WAIT_FOR_API" ]; then
   echo "Waiting for Monasca API to become available..."
   success="false"


### PR DESCRIPTION
A recent change to python-monascaclient removed ksclient, so using python-keystoneclient is now necessary to get a token to authenticate with the monasca client.

The keystone variables should only be set if they are not provided so that there is backwards compatibility with keystone v2