### PR TITLE
Add restart for ZK, Kafka and monasca-persister

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,11 @@ services:
 
   zookeeper:
     image: zookeeper:${ZOOKEEPER_VERSION}
+    restart: on-failure
+    
   kafka:
     image: monasca/kafka:${MON_KAFKA_VERSION}
+    restart: on-failure
     depends_on:
       - zookeeper
   kafka-init:
@@ -109,6 +112,7 @@ services:
 
   monasca-persister:
     image: monasca/persister:${MON_PERSISTER_VERSION}
+    restart: on-failure
     depends_on:
       - monasca
       - influxdb


### PR DESCRIPTION
restart: on-failure for Zookeeper, Kafka, and monasca-persister

See issue  #237
https://github.com/monasca/monasca-docker/issues/237