### PR TITLE
Display progress from stable/pike

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dockerfiles for Monasca
 
-[![Build Status](https://travis-ci.org/monasca/monasca-docker.svg?branch=master)](https://travis-ci.org/monasca/monasca-docker)
+[![Build Status](https://travis-ci.org/monasca/monasca-docker.svg?branch=stable/pike)](https://travis-ci.org/monasca/monasca-docker)
 
 This repository contains resources for building and deploying a full Monasca
 stack in Docker and Kubernetes environments.


### PR DESCRIPTION
Change the travis badge to refer to latest build from *stable/pike*