### PR TITLE
Change jvm options to MAXRAM

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -8,7 +8,7 @@ ARG SKIP_VERIFY=false
 
 ENV KAFKA_HOSTNAME_FROM_IP=true \
   ZOOKEEPER_CONNECTION_STRING=zookeeper:2181 \
-  KAFKA_MAX_HEAP_MB="1024"
+  KAFKA_MAX_MB="1024"
 
 COPY kafka_mirror.py /
 
@@ -28,7 +28,7 @@ RUN set -x && \
   rm /kafka.tar.gz /kafka_mirror.py && \
   apk del build-dep
 
-COPY template.py start.sh heap.py /
+COPY template.py start.sh memory.py /
 COPY templates /templates
 
 ENV PATH /kafka/bin:$PATH

--- a/kafka/build.yml
+++ b/kafka/build.yml
@@ -1,6 +1,6 @@
 repository: monasca/kafka
 variants:
-  - tag: 0.9.0.1-2.11-1.1.3
+  - tag: 0.9.0.1-2.11-1.1.4
     args:
       KAFKA_VERSION: "0.9.0.1"
       SCALA_VERSION: "2.11"

--- a/kafka/memory.py
+++ b/kafka/memory.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 import os
 import sys
 
-JVM_MAX_HEAP_RATIO = os.environ.get('JVM_MAX_HEAP_RATIO', '0.75')
-JVM_MAX_HEAP_MB = os.environ.get('JVM_MAX_HEAP_MB', None)
-HEAP_OVERRIDE_MB = os.environ.get('HEAP_OVERRIDE_MB', None)
+JVM_MAX_RATIO = os.environ.get('JVM_MAX_RATIO', '0.75')
+JVM_MAX_MB = os.environ.get('JVM_MAX_MB', None)
+MAX_OVERRIDE_MB = os.environ.get('MAX_OVERRIDE_MB', None)
 
 
 def get_system_memory_mb():
@@ -50,17 +50,17 @@ def get_effective_memory_limit_mb():
 
 
 def main():
-    if HEAP_OVERRIDE_MB:
-        print('{}m'.format(HEAP_OVERRIDE_MB))
+    if MAX_OVERRIDE_MB:
+        print('{}m'.format(MAX_OVERRIDE_MB))
         return
 
     system_max = get_system_memory_mb()
     cgroup_max = get_cgroup_memory_mb()
-    effective_max_ratio = float(JVM_MAX_HEAP_RATIO)
+    effective_max_ratio = float(JVM_MAX_RATIO)
     effective_max = int(min(system_max, cgroup_max) * effective_max_ratio)
 
-    if JVM_MAX_HEAP_MB:
-        env_max = int(JVM_MAX_HEAP_MB)
+    if JVM_MAX_MB:
+        env_max = int(JVM_MAX_MB)
     else:
         env_max = effective_max
 

--- a/kafka/start.sh
+++ b/kafka/start.sh
@@ -73,7 +73,7 @@ done
 
 if [ -z "$KAFKA_HEAP_OPTS" ]; then
   max_ram=$(python /memory.py "$KAFKA_MAX_MB")
-  KAFKA_HEAP_OPTS="-XX:MaxRAM=${max_ram} -XX:+UseSerialGC -Xss$KAFKA_STACK_SIZE"
+  KAFKA_HEAP_OPTS="-XX:MaxRAM=${max_ram} -Xss$KAFKA_STACK_SIZE"
   export KAFKA_HEAP_OPTS
 fi
 

--- a/kafka/start.sh
+++ b/kafka/start.sh
@@ -72,8 +72,8 @@ for f in $CONFIG_TEMPLATES/*.properties.j2; do
 done
 
 if [ -z "$KAFKA_HEAP_OPTS" ]; then
-  max_heap=$(python /heap.py "$KAFKA_MAX_HEAP_MB")
-  KAFKA_HEAP_OPTS="-Xmx${max_heap} -Xms${max_heap} -Xss$KAFKA_STACK_SIZE"
+  max_ram=$(python /memory.py "$KAFKA_MAX_MB")
+  KAFKA_HEAP_OPTS="-XX:MaxRAM=${max_ram} -XX:+UseSerialGC -Xss$KAFKA_STACK_SIZE"
   export KAFKA_HEAP_OPTS
 fi
 

--- a/monasca-thresh/README.md
+++ b/monasca-thresh/README.md
@@ -55,7 +55,7 @@ Configuration
 | `NO_STORM_CLUSTER`            | unset          | If `true`, run without Storm daemons     |
 | `STORM_WAIT_RETRIES`          | `24`           | # of tries to verify Storm availability  |
 | `STORM_WAIT_DELAY`            | `5`            | # seconds between retry attempts         |
-| `WORKER_MAX_HEAP_MB`          | unset          | If set and `NO_STORM_CLUSTER` is `true`, use as Heap Size for JVM |
+| `WORKER_MAX_MB`          | unset          | If set and `NO_STORM_CLUSTER` is `true`, use as MaxRam Size for JVM |
 | `METRIC_SPOUT_THREADS`        | `2`            | Metric Spout threads        |
 | `METRIC_SPOUT_TASKS`          | `2`            | Metric Spout tasks          |
 | `EVENT_SPOUT_THREADS`         | `2`            | Event Spout Threads         |

--- a/monasca-thresh/submit.sh
+++ b/monasca-thresh/submit.sh
@@ -60,7 +60,7 @@ fi
 if ${NO_STORM_CLUSTER} = "true"; then
   echo "Using Thresh Config file /storm/conf/thresh-config.yml. Contents:"
   cat /storm/conf/thresh-config.yml | grep -vi password
-  JAVAOPTS="-Xmx$(python /heap.py $WORKER_MAX_HEAP_MB) -Xss$THRESH_STACK_SIZE"
+  JAVAOPTS="-XX:MaxRAM=$(python /memory.py $WORKER_MAX_MB) -XX:+UseSerialGC -Xss$THRESH_STACK_SIZE"
   echo "Submitting storm topology as local cluster using JAVAOPTS of $JAVAOPTS"
   java $JAVAOPTS -classpath "/monasca-thresh.jar:/storm/lib/*" monasca.thresh.ThresholdingEngine /storm/conf/thresh-config.yml thresh-cluster local
   exit $?

--- a/monasca-thresh/submit.sh
+++ b/monasca-thresh/submit.sh
@@ -59,7 +59,7 @@ if ${NO_STORM_CLUSTER} = "true"; then
   echo "Using Thresh Config file /storm/conf/thresh-config.yml. Contents:"
   grep -vi password /storm/conf/thresh-config.yml
   # shellcheck disable=SC2086
-  JAVAOPTS="-XX:MaxRAM=$(python /memory.py $WORKER_MAX_MB) -XX:+UseSerialGC -Xss$THRESH_STACK_SIZE"
+  JAVAOPTS="-XX:MaxRAM=$(python /heap.py $WORKER_MAX_MB) -XX:+UseSerialGC -Xss$THRESH_STACK_SIZE"
   echo "Submitting storm topology as local cluster using JAVAOPTS of $JAVAOPTS"
   # shellcheck disable=SC2086
   java $JAVAOPTS -classpath "/monasca-thresh.jar:/storm/lib/*" monasca.thresh.ThresholdingEngine /storm/conf/thresh-config.yml thresh-cluster local

--- a/storm/Dockerfile
+++ b/storm/Dockerfile
@@ -10,11 +10,11 @@ ENV ZOOKEEPER_SERVERS="zookeeper" \
   ZOOKEEPER_PORT="2181" \
   ZOOKEEPER_WAIT="true" \
   SUPERVISOR_SLOTS_PORTS="6701,6702" \
-  SUPERVISOR_MAX_HEAP_MB="256" \
-  WORKER_MAX_HEAP_MB="784" \
+  SUPERVISOR_MAX_MB="256" \
+  WORKER_MAX_MB="784" \
   NIMBUS_SEEDS="storm-nimbus" \
-  NIMBUS_MAX_HEAP_MB="256" \
-  UI_MAX_HEAP_MB="768" \
+  NIMBUS_MAX_MB="256" \
+  UI_MAX_MB="768" \
   WORKER_LOGS_TO_STDOUT="false" \
   USE_SSL_ENABLED="true"
 
@@ -41,7 +41,7 @@ RUN mkdir /storm && \
 
 ENV PATH /storm/bin:$PATH
 
-COPY template.py heap.py entrypoint.sh /
+COPY template.py memory.py entrypoint.sh /
 COPY templates /templates
 COPY logging /logging
 

--- a/storm/README.md
+++ b/storm/README.md
@@ -68,13 +68,13 @@ similar). This behavior can be tuned as follows:
 
 | Variable             | Default | Description                                              |
 |----------------------|---------|----------------------------------------------------------|
-| `JVM_MAX_HEAP_RATIO` | `0.75`  | The max % of allocatable memory to pass to `-Xmx`        |
-| `JVM_MAX_HEAP_MB`    | unset   | Value to use for allocatable memory, autodetect if unset |
-| `HEAP_OVERRIDE_MB`   | unset   | Ignore scaling, always return `-Xmx$HEAP_OVERRIDE_MB`    |
-| `SUPERVISOR_MAX_HEAP_MB` | `256` | Max heap size in MiB for supervisor |
-| `WORKER_MAX_HEAP_MB`     | `784` | Max heap size in MiB for workers    |
-| `NIMBUS_MAX_HEAP_MB`     | `256` | Max heap in MiB for nimbus          |
-| `UI_MAX_HEAP_MB`         | `768` | Max heap in MiB for UI              |
+| `JVM_MAX_RATIO` | `0.75`  | The max % of allocatable memory to pass to `-XX:MaxRAM`       |
+| `JVM_MAX_MB`    | unset   | Value to use for allocatable memory, autodetect if unset |
+| `MAX_OVERRIDE_MB`   | unset   | Ignore scaling, always return `-XX:MaxRAM$MAX_OVERRIDE_MB` |
+| `SUPERVISOR_MAX_MB` | `256` | MaxRam of JVM in MiB for supervisor |
+| `WORKER_MAX_MB`     | `784` | MaxRam of JVM in MiB for workers    |
+| `NIMBUS_MAX_MB`     | `256` | MaxRam of JVM in MiB for nimbus          |
+| `UI_MAX_MB`         | `768` | MaxRam of JVM in MiB for UI              |
 | `SUPERVISOR_STACK_SIZE` | `1024k` | JVM stack size    |
 | `WORKER_STACK_SIZE`     | `1024k` | JVM stack size    |
 | `NIMBUS_STACK_SIZE`     | `1024k` | JVM stack size    |
@@ -83,13 +83,13 @@ similar). This behavior can be tuned as follows:
 Memory scaling is done based off of an automatically determined "effective"
 memory limit. The ultimate limit is either the true system memory limit or, if
 set, a limited value set via Docker's `--memory` flag (whichever value is
-smallest). This value is then scaled by `JVM_MAX_HEAP_RATIO` to ensure some
+smallest). This value is then scaled by `JVM_MAX_RATIO` to ensure some
 memory is left for other use.
 
-The final max heap size for each component is then the smallest of:
- * The component-specific memory request, e.g. `WORKER_MAX_HEAP_MB`
+The final max ram size for each component is then the smallest of:
+ * The component-specific memory request, e.g. `WORKER_MAX_MB`
  * The scaled allocatable memory (as described above)
- * If set, `JVM_MAX_HEAP_MB`
+ * If set, `JVM_MAX_MB`
 
 ### monasca-thresh
 

--- a/storm/build.yml
+++ b/storm/build.yml
@@ -1,13 +1,13 @@
 repository: monasca/storm
 variants:
-  - tag: 1.1.1-1.0.9
+  - tag: 1.1.1-1.0.10
     aliases:
       - :latest
       - :1.1.1
     args:
       STORM_VERSION: 1.1.1
 
-  - tag: 1.0.3-1.0.9
+  - tag: 1.0.3-1.0.10
     aliases:
       - :1.0.3
     args:

--- a/storm/entrypoint.sh
+++ b/storm/entrypoint.sh
@@ -70,12 +70,12 @@ if [ -z "$STORM_LOCAL_HOSTNAME" ]; then
 fi
 
 if [ -z "$SUPERVISOR_CHILDOPTS" ]; then
-  SUPERVISOR_CHILDOPTS="-Xmx$(python /heap.py "$SUPERVISOR_MAX_HEAP_MB") -Xss$SUPERVISOR_STACK_SIZE"
+  SUPERVISOR_CHILDOPTS="-XX:MaxRAM$(python /memory.py "$SUPERVISOR_MAX_MB") -XX:+UseSerialGC -Xss$SUPERVISOR_STACK_SIZE"
   export SUPERVISOR_CHILDOPTS
 fi
 
 if [ -z "$WORKER_CHILDOPTS" ]; then
-  WORKER_CHILDOPTS="-Xmx$(python /heap.py "$WORKER_MAX_HEAP_MB") -Xss$WORKER_STACK_SIZE"
+  WORKER_CHILDOPTS="-XX:MaxRAM$(python /memory.py "$WORKER_MAX_MB") -Xss$WORKER_STACK_SIZE"
   WORKER_CHILDOPTS="$WORKER_CHILDOPTS -XX:+UseConcMarkSweepGC"
   if [ "$WORKER_REMOTE_JMX" = "true" ]; then
     WORKER_CHILDOPTS="$WORKER_CHILDOPTS -Dcom.sun.management.jmxremote"
@@ -85,12 +85,12 @@ if [ -z "$WORKER_CHILDOPTS" ]; then
 fi
 
 if [ -z "$NIMBUS_CHILDOPTS" ]; then
-  NIMBUS_CHILDOPTS="-Xmx$(python /heap.py "$NIMBUS_MAX_HEAP_MB") -Xss$NIMBUS_STACK_SIZE"
+  NIMBUS_CHILDOPTS="-XX:MaxRAM$(python /memory.py "$NIMBUS_MAX_MB") -XX:+UseSerialGC -Xss$NIMBUS_STACK_SIZE"
   export NIMBUS_CHILDOPTS
 fi
 
 if [ -z "$UI_CHILDOPTS" ]; then
-  UI_CHILDOPTS="-Xmx$(python /heap.py "$UI_MAX_HEAP_MB") -Xss$UI_STACK_SIZE"
+  UI_CHILDOPTS="-XX:MaxRAM$(python /memory.py "$UI_MAX_MB") -XX:+UseSerialGC -Xss$UI_STACK_SIZE"
   export UI_CHILDOPTS
 fi
 

--- a/storm/memory.py
+++ b/storm/memory.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 import os
 import sys
 
-JVM_MAX_HEAP_RATIO = os.environ.get('JVM_MAX_HEAP_RATIO', '0.75')
-JVM_MAX_HEAP_MB = os.environ.get('JVM_MAX_HEAP_MB', None)
-HEAP_OVERRIDE_MB = os.environ.get('HEAP_OVERRIDE_MB', None)
+JVM_MAX_RATIO = os.environ.get('JVM_MAX_RATIO', '0.75')
+JVM_MAX_MB = os.environ.get('JVM_MAX_MB', None)
+MAX_OVERRIDE_MB = os.environ.get('MAX_OVERRIDE_MB', None)
 
 
 def get_system_memory_mb():
@@ -50,17 +50,17 @@ def get_effective_memory_limit_mb():
 
 
 def main():
-    if HEAP_OVERRIDE_MB:
-        print('{}m'.format(HEAP_OVERRIDE_MB))
+    if MAX_OVERRIDE_MB:
+        print('{}m'.format(MAX_OVERRIDE_MB))
         return
 
     system_max = get_system_memory_mb()
     cgroup_max = get_cgroup_memory_mb()
-    effective_max_ratio = float(JVM_MAX_HEAP_RATIO)
+    effective_max_ratio = float(JVM_MAX_RATIO)
     effective_max = int(min(system_max, cgroup_max) * effective_max_ratio)
 
-    if JVM_MAX_HEAP_MB:
-        env_max = int(JVM_MAX_HEAP_MB)
+    if JVM_MAX_MB:
+        env_max = int(JVM_MAX_MB)
     else:
         env_max = effective_max
 


### PR DESCRIPTION
Right now we only limit stack size and heap but that is not the
whole jvm causing OOM issues. The max ram option should cap all
memory used by the JVM