### PR TITLE
Fix getopt call in monasca-python/build.sh

### DIFF
--- a/monasca-python/build.sh
+++ b/monasca-python/build.sh
@@ -73,8 +73,11 @@ CONSTRAINTS=""
 CONSTRAINTS_URL=""
 CONSTRAINTS_BRANCH=""
 
-if OPTS=$(getopt -n 'parse-options' -o r:b:e:d:c:u:q: -- "$@"); then
-echo "Failed parsing options." >&2 ; exit 1 ; fi
+OPTS=`getopt -n 'parse-options' -o r:b:e:d:c:u:q: -- "$@"`
+if [ $? != 0 ]; then
+  echo "Failed parsing options." >&2
+  exit 1
+fi
 
 echo "$OPTS"
 eval set -- "$OPTS"

--- a/monasca-python/build.sh
+++ b/monasca-python/build.sh
@@ -73,8 +73,7 @@ CONSTRAINTS=""
 CONSTRAINTS_URL=""
 CONSTRAINTS_BRANCH=""
 
-OPTS=`getopt -n 'parse-options' -o r:b:e:d:c:u:q: -- "$@"`
-if [ $? != 0 ]; then
+if ! OPTS=$(getopt -n 'parse-options' -o r:b:e:d:c:u:q: -- "$@"); then
   echo "Failed parsing options." >&2
   exit 1
 fi


### PR DESCRIPTION
The change made the getopt call check for success instead of failure.