### PR TITLE
Use valid python base image for monasca/client 1.8.0 and master

### DIFF
--- a/monasca-client/build.yml
+++ b/monasca-client/build.yml
@@ -8,7 +8,7 @@ variants:
     args:
       CLIENT_BRANCH: 1.8.0
       PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20171024-093600
+      TIMESTAMP_SLUG: 20171101-203148
       CONSTRAINTS_BRANCH: master
 
   - tag: 1.7.0
@@ -36,5 +36,5 @@ variants:
     args:
       CLIENT_BRANCH: master
       PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20171024-093600
+      TIMESTAMP_SLUG: 20171101-203148
       CONSTRAINTS_BRANCH: master


### PR DESCRIPTION
The merge build for https://github.com/monasca/monasca-docker/pull/311 failed because of the bug fixed in #314. This updates `monasca/client` to use the new image so the build can pass again.