### PR TITLE
Allow kafka container to stay alive after kafka exits

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -68,6 +68,7 @@ Several parameters can be specified using environment variables:
 | `KAFKA_STACK_SIZE`            | `1024k` | JVM stack size                                 |
 | `LOG_RETENTION_HOURS`         | `4`     | Number of hours to keep a log file             |
 | `LOG_ROLL_MS`                 | `900000` | Number of ms before a new log segment is rolled out |
+| `STAY_ALIVE_ON_FAILURE`       | `false` | If `true`, container stays alive for 2 hours after kafka exits |
 
 ### Log Files
 

--- a/kafka/build.yml
+++ b/kafka/build.yml
@@ -1,6 +1,6 @@
 repository: monasca/kafka
 variants:
-  - tag: 0.9.0.1-2.11-1.1.5
+  - tag: 0.9.0.1-2.11-1.1.6
     args:
       KAFKA_VERSION: "0.9.0.1"
       SCALA_VERSION: "2.11"


### PR DESCRIPTION
This will allow debugging of error conditions and handling problems
like a full disk.