### PR TITLE
Add 'domain_roles' to user object

### DIFF
--- a/keystone-init/README.md
+++ b/keystone-init/README.md
@@ -108,6 +108,7 @@ domains:
       - username: test-user
         project: some-project
         roles: [a, b, c]
+        domain_roles: [d, e, f]
         secret: some-secret-name
 ```
 

--- a/keystone-init/build.yml
+++ b/keystone-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/keystone-init
 variants:
   - tag: latest
     aliases:
-      - :1.2.0
+      - :1.2.1
       - :1.2
       - :1


### PR DESCRIPTION
Adds 'domain_roles' to the user object which acts similarly to 'roles' but applied
to the domain element of which the user is a child.