### PR TITLE
Allow project role grants for groups

### DIFF
--- a/keystone-init/README.md
+++ b/keystone-init/README.md
@@ -68,6 +68,7 @@ domains:
     projects: []
     roles: []
     users: []
+    groups: []
 
 services:
   example:
@@ -179,6 +180,21 @@ containers:
         value: some-value
 # adjust indent() as necessary
 {{ include "keystone_env" .Values.my_pod.auth | indent(6) }}
+```
+
+The `groups` block can contain a list of groups to be created. The list
+can consist of group names as string values, or objects containing role
+grants. For instance:
+```yaml
+domains:
+  default:
+    groups:
+      - a
+      - name: b
+        project_roles:
+          - project: c
+            roles: d, e
+
 ```
 
 Services are created by their unique name:

--- a/keystone-init/build.yml
+++ b/keystone-init/build.yml
@@ -2,6 +2,6 @@ repository: monasca/keystone-init
 variants:
   - tag: latest
     aliases:
-      - :1.2.1
+      - :1.2.2
       - :1.2
       - :1

--- a/keystone-init/preload.yml
+++ b/keystone-init/preload.yml
@@ -5,6 +5,7 @@ domains:
     projects: []
     roles: []
     users: []
+    groups: []
 
 services:
   example:


### PR DESCRIPTION
Allow elements in domain.groups to be dictionaries containing
name and project_roles, each of which must have a 'project' and
list of 'roles' to be granted