### PR TITLE
Change default value of DELEGATE_AUTHORIZED_ROLES

### DIFF
--- a/monasca-api-python/README.md
+++ b/monasca-api-python/README.md
@@ -98,7 +98,7 @@ A number of environment variables can be passed to the container:
 | `AUTHORIZED_ROLES`           | `user, domainuser, domainadmin, monasca-user` | Roles for admin Users |
 | `AGENT_AUTHORIZED_ROLES`     | `monasca-agent` | Roles for metric write only users |
 | `READ_ONLY_AUTHORIZED_ROLES` | `monasca-read-only-user` | Roles for read only users    |
-| `DELEGATE_AUTHORIZED_ROLES`  | `admin`       | Roles allow to read/write cross tenant ID |
+| `DELEGATE_AUTHORIZED_ROLES`  | `monitoring-delegate` | Roles allow to read/write cross tenant ID |
 | `ADD_ACCESS_LOG`  | `true`       | if true, produce an access log on stderr |
 | `ACCESS_LOG_FORMAT`  | `%(asctime)s [%(process)d] gunicorn.access [%(levelname)s] %(message)s` | Log format for access log |
 | `ACCESS_LOG_FIELDS`  | `%(h)s %(l)s %(u)s %(t)s %(r)s %(s)s %(b)s "%(f)s" "%(a)s" %(L)s` | Access log fields |

--- a/monasca-api-python/api-config.conf.j2
+++ b/monasca-api-python/api-config.conf.j2
@@ -34,7 +34,7 @@ read_only_authorized_roles = {{ READ_ONLY_AUTHORIZED_ROLES | default('monasca-re
 
 # The roles that are allowed to access the API on behalf of another tenant.
 # For example, a service can POST metrics to another tenant if they are a member of the "delegate" role.
-delegate_authorized_roles = {{ DELEGATE_AUTHORIZED_ROLES | default('admin') }}
+delegate_authorized_roles = {{ DELEGATE_AUTHORIZED_ROLES | default('monitoring-delegate') }}
 
 [messaging]
 # The message queue driver to use


### PR DESCRIPTION
Change default value of DELEGATE_AUTHORIZED_ROLES from `admin` to
`monitoring-delegate` because of following two reasons.
- There is inconsistency between monasca-docker default value and
OpenStack monasca agent project document.
- It's not secure to allow admin authorization to other users.

(cherry picked from commit 88c254b1f627a525beab85c6a876f81bfcb03ab1)