### PR TITLE
Fix job-cleanup for 1.8.0

### DIFF
--- a/job-cleanup/build.yml
+++ b/job-cleanup/build.yml
@@ -2,5 +2,5 @@ repository: monasca/job-cleanup
 variants:
   - tag: latest
     aliases:
-      - :1.2.0
+      - :1.2.1
       - :1.2

--- a/job-cleanup/cleanup.py
+++ b/job-cleanup/cleanup.py
@@ -27,7 +27,7 @@ from dotmap import DotMap
 from tiny_kubernetes import KubernetesAPIClient
 
 NAMESPACE = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
-TIMEOUT = float(os.environ.get('WAIT_TIMEOUT', '10'))
+TIMEOUT = int(os.environ.get('WAIT_TIMEOUT', '10'))
 RETRIES = int(os.environ.get('WAIT_RETRIES', '5'))
 RETRY_DELAY = float(os.environ.get('WAIT_DELAY', '5.0'))
 
@@ -84,8 +84,7 @@ def try_delete_job(client: KubernetesAPIClient,
             return False, retries - 1
 
     grace_period = 0 if force else TIMEOUT
-    delete_options = {'propagationPolicy': 'Foreground',
-                      'gracePeriodSeconds': grace_period}
+    delete_options = {'gracePeriodSeconds': grace_period}
 
     job_name = job.metadata.name
     pods = client.get('/api/v1/namespaces/{}/pods', namespace,


### PR DESCRIPTION
Kubernetes 1.8.0 validates delete options more strictly, and we passed
a float instead of an int. Also removes propagationPolicy since it is
effectively a no-op.

Fixes monasca/monasca-helm#349