### PR TITLE
Bump version for tempest tests container

### DIFF
--- a/tempest-tests/build.yml
+++ b/tempest-tests/build.yml
@@ -1,5 +1,5 @@
 repository: monasca/tempest-tests
 variants:
-  - tag: 1.0.1
+  - tag: 1.0.2
     aliases:
       - :latest


### PR DESCRIPTION
New Monasca API requires a new tempest test container as "{}" is
now allowed in dimension names and values