### PR TITLE
Hide Monasca password from ps

### DIFF
--- a/monasca-api-python/Dockerfile
+++ b/monasca-api-python/Dockerfile
@@ -49,12 +49,6 @@ COPY template.py start.sh health-check.sh kafka_wait_for_topics.py /
 EXPOSE 8070
 
 HEALTHCHECK --interval=10s --timeout=5s \
-  CMD /health-check.sh \
-    $KEYSTONE_AUTH_URI \
-    $KEYSTONE_ADMIN_USER \
-    $KEYSTONE_ADMIN_PASSWORD \
-    $KEYSTONE_ADMIN_TENANT \
-    $KEYSTONE_ADMIN_DOMAIN \
-    $MONASCA_CONTAINER_API_PORT
+  CMD /health-check.sh
 
 CMD ["/start.sh"]

--- a/monasca-api-python/health-check.sh
+++ b/monasca-api-python/health-check.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 # Default values for executing it manually on the host
-KEYSTONE_AUTH_URI=${1:-http://localhost:5000}
-KEYSTONE_ADMIN_USER=${2:-admin}
-KEYSTONE_ADMIN_PASSWORD=${3:-secretadmin}
-KEYSTONE_ADMIN_TENANT=${4:-admin}
-KEYSTONE_ADMIN_DOMAIN=${5:-default}
-MONASCA_CONTAINER_API_PORT=${6:-8070}
+KEYSTONE_AUTH_URI=${KEYSTONE_AUTH_URI:-http://localhost:5000}
+KEYSTONE_ADMIN_USER=${KEYSTONE_ADMIN_USER:-admin}
+KEYSTONE_ADMIN_PASSWORD=${KEYSTONE_ADMIN_PASSWORD:-secretadmin}
+KEYSTONE_ADMIN_TENANT=${KEYSTONE_ADMIN_TENANT:-admin}
+KEYSTONE_ADMIN_DOMAIN=${KEYSTONE_ADMIN_DOMAIN:-default}
+MONASCA_CONTAINER_API_PORT=${MONASCA_CONTAINER_API_PORT:-8070}
 
 KEYSTONE_TOKEN=$(curl --include --silent --show-error --output - --header "Content-Type:application/json" \
     --data '{ "auth": {


### PR DESCRIPTION
If you so happened to do a ps -ef while a HEALTHCHECK is running for the API, then you would see a plaintext password. This changes the HEALTHCHECK to use environment variables to avoid that problem.