### PR TITLE
Use monasca org Grafana app repo in Dockerfile

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -4,7 +4,7 @@ arg GRAFANA_REPO=https://github.com/monasca/grafana.git
 arg GRAFANA_BRANCH=grafana4
 arg MONASCA_DATASOURCE_REPO=https://git.openstack.org/openstack/monasca-grafana-datasource
 arg MONASCA_DATASOURCE_BRANCH=master
-arg MONASCA_APP_REPO=https://github.com/stackhpc/monasca-grafana-app
+arg MONASCA_APP_REPO=https://github.com/monasca/monasca-grafana.git
 arg MONASCA_APP_BRANCH=master
 
 # To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running

--- a/grafana/build.yml
+++ b/grafana/build.yml
@@ -2,6 +2,6 @@ repository: monasca/grafana
 variants:
   - tag: latest
     aliases:
-      - :4.0.0-1.3.4
+      - :4.0.0-1.3.5
     args:
       MONASCA_APP_REPO: https://github.com/monasca/monasca-grafana.git


### PR DESCRIPTION
Proper repo was used only when building in Travis, local builds was
still using old repository.