### PR TITLE
Don't leak environment variables

### DIFF
--- a/monasca-agent-forwarder/start.sh
+++ b/monasca-agent-forwarder/start.sh
@@ -2,8 +2,6 @@
 # shellcheck shell=dash
 # (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 
-set -x
-
 AGENT_CONF="/etc/monasca/agent"
 
 if [ "$KEYSTONE_DEFAULTS_ENABLED" = "true" ]; then
@@ -14,6 +12,8 @@ if [ "$KEYSTONE_DEFAULTS_ENABLED" = "true" ]; then
   export OS_PROJECT_NAME=${OS_PROJECT_NAME:-"mini-mon"}
   export OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-"Default"}
 fi
+
+set -x
 
 template () {
   if [ "$CONFIG_TEMPLATE" = "true" ]; then

--- a/monasca-agent-forwarder/start.sh
+++ b/monasca-agent-forwarder/start.sh
@@ -1,6 +1,6 @@
 #!/bin/ash
 # shellcheck shell=dash
-# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017-2018 Hewlett Packard Enterprise Development LP
 
 AGENT_CONF="/etc/monasca/agent"
 


### PR DESCRIPTION
`set -x` was leaking several potentially secret  environment variable
values into log files.

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>