### PR TITLE
Use Drizzle SQL connector in monasca-thresh

### DIFF
--- a/monasca-thresh/Dockerfile
+++ b/monasca-thresh/Dockerfile
@@ -1,4 +1,4 @@
-FROM monasca/storm:1.1.1-1.0.11
+FROM monasca/storm:1.1.1-1.0.12
 
 ENV MAVEN_HOME /usr/share/maven
 

--- a/monasca-thresh/Dockerfile
+++ b/monasca-thresh/Dockerfile
@@ -1,4 +1,4 @@
-FROM monasca/storm:1.1.1-1.0.12
+FROM monasca/storm:1.1.1-1.0.11
 
 ENV MAVEN_HOME /usr/share/maven
 

--- a/storm/build.yml
+++ b/storm/build.yml
@@ -1,6 +1,6 @@
 repository: monasca/storm
 variants:
-  - tag: 1.1.1-1.0.11
+  - tag: 1.1.1-1.0.12
     aliases:
       - :latest
       - :1.1.1

--- a/storm/templates/thresh-config.yml.j2
+++ b/storm/templates/thresh-config.yml.j2
@@ -120,8 +120,8 @@ sporadicMetricNamespaces:
   - foo
 
 database:
-  driverClass: com.mysql.jdbc.Driver
-  url: "jdbc:mysql://{{ MYSQL_DB_HOST | default('mysql') }}:{{ MYSQL_DB_PORT | default('3306') }}/{{ MYSQL_DB_DATABASE | default('mon') }}?useSSL={{ USE_SSL_ENABLED }}"
+  driverClass: org.drizzle.jdbc.DrizzleDriver
+  url: "jdbc:drizzle://{{ MYSQL_DB_HOST | default('mysql') }}:{{ MYSQL_DB_PORT | default('3306') }}/{{ MYSQL_DB_DATABASE | default('mon') }}"
   user: "{{ MYSQL_DB_USERNAME | default('thresh') }}"
   password: "{{ MYSQL_DB_PASSWORD | default('password') }}"
   properties:


### PR DESCRIPTION
I have [proposed](https://review.openstack.org/541369) to remove MySQL Connector from monasca-thresh package and use Drizzle instead.
Please let me know if you see any issues with that.