### PR TITLE
Fix monasca-aggregator build

### DIFF
--- a/monasca-aggregator/Dockerfile
+++ b/monasca-aggregator/Dockerfile
@@ -1,5 +1,5 @@
 # librdkafka is not available in a stable alpine release
-from alpine:edge
+from alpine:3.7
 
 arg AGGREGATOR_REPO=https://github.com/monasca/monasca-aggregator
 arg AGGREGATOR_BRANCH=master

--- a/monasca-aggregator/Dockerfile
+++ b/monasca-aggregator/Dockerfile
@@ -1,4 +1,3 @@
-# librdkafka is not available in a stable alpine release
 from alpine:3.7
 
 arg AGGREGATOR_REPO=https://github.com/monasca/monasca-aggregator

--- a/monasca-aggregator/build.yml
+++ b/monasca-aggregator/build.yml
@@ -1,5 +1,5 @@
 repository: monasca/aggregator
 variants:
-  - tag: 0.1.5
+  - tag: latest
     aliases:
-      - :latest
+      - :0.1.6


### PR DESCRIPTION
Building of confluent-kafka-go is currently broken on go v1.9.4 which
is currently shipping with alpine:edge [1]. This switches the image
build to alpine:3.7 which does now have this problem, however we may
run into issues upgrading to later versions if confluent-kafka-go
doesn't find a workaround for the underlying problem.

[1] https://github.com/confluentinc/confluent-kafka-go/issues/137

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>