### PR TITLE
[aggregator] Move config files to subdirectories

### DIFF
--- a/monasca-aggregator/Dockerfile
+++ b/monasca-aggregator/Dockerfile
@@ -5,7 +5,7 @@ arg AGGREGATOR_BRANCH=master
 
 env GOPATH=/go
 
-run apk add --no-cache openssl py2-jinja2 && \
+run apk add --no-cache openssl py2-jinja2 librdkafka && \
   apk add --no-cache --virtual build-dep \
     librdkafka-dev git go glide make g++ openssl-dev && \
   mkdir -p $GOPATH/src/github.com/monasca/monasca-aggregator && \
@@ -15,14 +15,16 @@ run apk add --no-cache openssl py2-jinja2 && \
   git fetch origin $AGGREGATOR_BRANCH && \
   git reset --hard FETCH_HEAD && \
   glide install && \
-  go build -tags static && \
+  go build && \
   cp monasca-aggregator /monasca-aggregator && \
-  cp aggregation-specifications.yaml / && \
+  mkdir /specs && \
+  cp aggregation-specifications.yaml /specs && \
   apk del build-dep && \
   cd / && \
   rm -rf /go
 
-copy config.yaml.j2 template.py start.sh /
+copy template.py start.sh /
+copy config.yaml.j2 /config/config.yaml.j2
 expose 8080
 
 cmd ["/start.sh"]

--- a/monasca-aggregator/build.yml
+++ b/monasca-aggregator/build.yml
@@ -2,4 +2,4 @@ repository: monasca/aggregator
 variants:
   - tag: latest
     aliases:
-      - :0.1.6
+      - :0.2.0

--- a/monasca-aggregator/start.sh
+++ b/monasca-aggregator/start.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
-python /template.py config.yaml.j2 config.yaml
+python /template.py /config/config.yaml.j2 config.yaml
+
+# works around a recent Kubernetes issue where subpath mounts are broken
+# we need to mount the aggregation specifications configmap into its own
+# directory rather than using subpath mounts
+specs_input=${AGGREGATION_SPECIFICATIONS:-"/specs/aggregation-specifications.yaml"}
+if [ -e "$specs_input" ]; then
+  echo "copying $specs_input to /"
+  cp "$specs_input" /aggregation-specifications.yaml
+fi
 
 /monasca-aggregator


### PR DESCRIPTION
Due to a recent Kubernetes CVE, subpath mounting (which allowed
single-file mounts to `/`) is broken. As the old aggregator image
expected to find its config files in `/`, it won't run in affected
versions.

This adds a workaround to `start.sh` so `config.yaml.j2` is copied
from `/config` and `aggregation-specifications.yaml` is copied from
in `/specs`. This allows ConfigMaps to be mounted to these individual
directories without any trouble.

As this is a breaking change to the aggregator image, this is a new
minor version release.

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>