### PR TITLE
Temporarily disable shellcheck to unblock CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ services:
   - docker
 language: python
 
+# NOTE (timothyb89) 27 April 2018 - shellcheck on travis is currently broken
+# so, disable for now
+# see also: https://github.com/travis-ci/travis-ci/issues/9484
+
+
 addons:
   apt:
-    sources:
-    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
+#    sources:
+#    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
     packages:
-    - shellcheck
+#    - shellcheck
     - docker-ce
 
 env:
@@ -23,8 +28,8 @@ before_install:
 
 jobs:
   include:
-    - stage: lint-shellcheck
-      script: bash -c 'shopt -s globstar; shellcheck **/*.sh'
+#    - stage: lint-shellcheck
+#      script: bash -c 'shopt -s globstar; shellcheck **/*.sh'
     - stage: metrics-pipeline
       script: python ci.py metrics
     - stage: logs-pipeline


### PR DESCRIPTION
It looks like travis is experiencing issues with debian's shellcheck
package at the moment [1], so let's disable the shellcheck job for
now to unblock CI.

[1] https://github.com/travis-ci/travis-ci/issues/9484

Signed-off-by: Tim Buckley <timothy.jas.buckley@hpe.com>