### PR TITLE
Upgrade the storm to 1.1.3

### DIFF
--- a/storm/Dockerfile
+++ b/storm/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-ARG STORM_VERSION=1.1.1
+ARG STORM_VERSION=1.1.3
 ARG STORM_KEYS=https://dist.apache.org/repos/dist/release/storm/KEYS
 ARG ASC_MIRROR=https://dist.apache.org/repos/dist/release/storm
 ARG SKIP_VERIFY=false

--- a/storm/build.yml
+++ b/storm/build.yml
@@ -1,11 +1,11 @@
 repository: monasca/storm
 variants:
-  - tag: 1.1.1-1.0.12
+  - tag: 1.1.3-1.0.12
     aliases:
       - :latest
-      - :1.1.1
+      - :1.1.3
     args:
-      STORM_VERSION: 1.1.1
+      STORM_VERSION: 1.1.3
 
   - tag: 1.0.3-1.0.10
     aliases:


### PR DESCRIPTION
Storm 1.1.1 is affected by the security bug CVE-2018-1332 [1].
It is recommended to upgrade to 1.1.3 (the latest release at the moment).

[1]: http://www.securityfocus.com/bid/104399

Signed-off-by: Dobroslaw Zybort <dobroslaw.zybort@ts.fujitsu.com>