### PR TITLE
Added restart on failure to logspout container

### DIFF
--- a/log-pipeline.yml
+++ b/log-pipeline.yml
@@ -114,5 +114,6 @@ services:
       LOGSTASH_FIELDS: "service=logspout"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+    restart: on-failure
     depends_on:
         - log-agent


### PR DESCRIPTION
Bug description: The start of the logspout fails waiting for
log-agent to become ready after 24 attempts. Then, no logs are
collected from the containers.

Fix: Add restart parameter to the logspout container, since
the parameter depends_on log-agent is necessary but not sufficient.

Scenario: Deploying the log-pipeline in an OpenStack virtual
instance with Ubuntu 16.04, 2vCPU, 15GB RAM and 50GB SSD.