### PR TITLE
Fix multiline logs

### DIFF
--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -3,7 +3,7 @@ FROM gliderlabs/logspout:${LOGSPOUT_VERSION}
 
 ENV MONASCA_WAIT_FOR_LOG_AGENT=true \
     MONASCA_LOG_AGENT_URI=log-agent:5610 \
-    ROUTE_URIS=logstash+tcp://log-agent:5610
+    ROUTE_URIS=multiline+logstash+tcp://log-agent:5610
 
 COPY start.sh wait-for.sh /
 

--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -5,7 +5,7 @@ ENV MONASCA_WAIT_FOR_LOG_AGENT=true \
     MONASCA_LOG_AGENT_URI=log-agent:5610 \
     ROUTE_URIS=multiline+logstash+tcp://log-agent:5610 \
     MULTILINE_MATCH=first \
-    MULTILINE_PATTERN=^(\\d{4}-\\d{2}-\\d{2}|{|\\[\\d{4}-\\d{2}-\\d{2})
+    MULTILINE_PATTERN=^(\\[?\\d{4}-\\d{2}-\\d{2}|{)
 
 COPY start.sh wait-for.sh /
 

--- a/logspout/Dockerfile
+++ b/logspout/Dockerfile
@@ -3,7 +3,9 @@ FROM gliderlabs/logspout:${LOGSPOUT_VERSION}
 
 ENV MONASCA_WAIT_FOR_LOG_AGENT=true \
     MONASCA_LOG_AGENT_URI=log-agent:5610 \
-    ROUTE_URIS=multiline+logstash+tcp://log-agent:5610
+    ROUTE_URIS=multiline+logstash+tcp://log-agent:5610 \
+    MULTILINE_MATCH=first \
+    MULTILINE_PATTERN=^(\\d{4}-\\d{2}-\\d{2}|{|\\[\\d{4}-\\d{2}-\\d{2})
 
 COPY start.sh wait-for.sh /
 

--- a/logspout/README.md
+++ b/logspout/README.md
@@ -30,10 +30,10 @@ to the Monasca Log Agent.
 Configuration
 -------------
 
-|        Variable         |             Default             |             Description             |
-|-------------------------|---------------------------------|-------------------------------------|
-| `MONASCA_LOG_AGENT_URI` | `log-agent:5610`                | Monasca Log Agent connection string |
-| `ROUTE_URIS`            | `logstash+tcp://log-agent:5610` | Logstash connection string          |
+|        Variable         |                 Default                   |             Description             |
+|-------------------------|-------------------------------------------|-------------------------------------|
+| `MONASCA_LOG_AGENT_URI` | `log-agent:5610`                          | Monasca Log Agent connection string |
+| `ROUTE_URIS`            | `multiline+logstash+tcp://log-agent:5610` | Logstash connection string          |
 
 Additional files
 ----------------

--- a/logspout/README.md
+++ b/logspout/README.md
@@ -27,7 +27,7 @@ as a value e.g.: `"service=mysql"`.
 Logspout will pickup this env variable and send proper data
 to the Monasca Log Agent.
 
-To handle multiline logs [5] you need to pass a regex as a environment variable,
+To handle [multiline logs][5] you need to pass a regex as a environment variable,
 which matches the start of the multiline blocks e.g.:
 
 `MULTILINE_PATTERN=^(\\d{4}-\\d{2}-\\d{2}|{|\\[\\d{4}-\\d{2}-\\d{2})`

--- a/logspout/README.md
+++ b/logspout/README.md
@@ -27,14 +27,21 @@ as a value e.g.: `"service=mysql"`.
 Logspout will pickup this env variable and send proper data
 to the Monasca Log Agent.
 
-To handle [multiline logs][5] you need to pass a regex as a environment variable,
+Multiline logging
+-----------------
+
+To handle [multiline logging][5] you need to pass a regex as a environment variable,
 which matches the start of the multiline blocks e.g.:
-
 `MULTILINE_PATTERN=^(\\d{4}-\\d{2}-\\d{2}|{|\\[\\d{4}-\\d{2}-\\d{2})`
-This example matches logs starting with `YYYY-MM-DD`, `[YYYY-MM-DD` and json-logs.
 
-`MULTILINE_FLUSH_AFTER` defines the maximum time between the first and last lines
-of a multiline log entry in milliseconds (default: 500)
+This example matches logs, which:
+
+* start with a timestamp with format `YYYY-MM-DD`
+* are json-logs
+* start with a timestamp with format `[YYYY-MM-DD`
+
+Note that in the case of a service generates logs, which don't follow any of these patterns,
+the multiline bock will be chunked every period defined with `MULTILINE_FLUSH_AFTER` (default: 500 ms)
 
 Configuration
 -------------

--- a/logspout/README.md
+++ b/logspout/README.md
@@ -32,13 +32,12 @@ Multiline logging
 
 To handle [multiline logging][5] you need to pass a regex as a environment variable,
 which matches the start of the multiline blocks e.g.:
-`MULTILINE_PATTERN=^(\\d{4}-\\d{2}-\\d{2}|{|\\[\\d{4}-\\d{2}-\\d{2})`
+`MULTILINE_PATTERN=^(\\[?\\d{4}-\\d{2}-\\d{2}|{)`
 
 This example matches logs, which:
 
-* start with a timestamp with format `YYYY-MM-DD`
+* start with a timestamp with format `YYYY-MM-DD` or `[YYYY-MM-DD`
 * are json-logs
-* start with a timestamp with format `[YYYY-MM-DD`
 
 Note that in the case of a service generates logs, which don't follow any of these patterns,
 the multiline bock will be chunked every period defined with `MULTILINE_FLUSH_AFTER` (default: 500 ms)

--- a/logspout/README.md
+++ b/logspout/README.md
@@ -27,6 +27,15 @@ as a value e.g.: `"service=mysql"`.
 Logspout will pickup this env variable and send proper data
 to the Monasca Log Agent.
 
+To handle multiline logs [5] you need to pass a regex as a environment variable,
+which matches the start of the multiline blocks e.g.:
+
+`MULTILINE_PATTERN=^(\\d{4}-\\d{2}-\\d{2}|{|\\[\\d{4}-\\d{2}-\\d{2})`
+This example matches logs starting with `YYYY-MM-DD`, `[YYYY-MM-DD` and json-logs.
+
+`MULTILINE_FLUSH_AFTER` defines the maximum time between the first and last lines
+of a multiline log entry in milliseconds (default: 500)
+
 Configuration
 -------------
 
@@ -46,3 +55,4 @@ with needed plugin.
 [2]: https://github.com/looplab/logspout-logstash
 [3]: http://semver.org/
 [4]: https://github.com/monasca/monasca-docker/tree/master/monasca-log-agent
+[5]: https://github.com/gliderlabs/logspout/#multiline-logging

--- a/logspout/build.yml
+++ b/logspout/build.yml
@@ -1,7 +1,7 @@
 repository: monasca/logspout
 variants:
-  - tag: 0.0.2
+  - tag: 0.1.0
     aliases:
       - :latest
     args:
-      LOGSPOUT_VERSION: v3.2.3
+      LOGSPOUT_VERSION: v3.2.6

--- a/logspout/modules.go
+++ b/logspout/modules.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	_ "github.com/gliderlabs/logspout/adapters/multiline"
 	_ "github.com/gliderlabs/logspout/transports/tcp"
 	_ "github.com/gliderlabs/logspout/transports/udp"
 	_ "github.com/looplab/logspout-logstash"


### PR DESCRIPTION
Added multiline-log feature

- From v3.2.5 logspout supports multiline-logs [1]

[1] https://github.com/gliderlabs/logspout/tree/v3.2.5#multiline-logging