### PR TITLE
aggregator lack of loglevel property

### DIFF
--- a/monasca-aggregator/build.yml
+++ b/monasca-aggregator/build.yml
@@ -2,4 +2,4 @@ repository: monasca/aggregator
 variants:
   - tag: latest
     aliases:
-      - :0.2.1
+      - :0.3.0

--- a/monasca-aggregator/config.yaml.j2
+++ b/monasca-aggregator/config.yaml.j2
@@ -2,7 +2,8 @@ windowSize: {{ AGGREGATION_WINDOW_SIZE | default('10') }}
 windowLag: {{ AGGREGATION_WINDOW_LAG | default('2') }}
 consumerTopic: {{ AGGREGATION_CONSUMER_TOPIC | default('metrics') }}
 producerTopic: {{ AGGREGATION_PRODUCER_TOPIC | default('metrics') }}
-logging.level: {{LOGGING_LEVEL | default('warning') }}
+logging:
+  level: {{LOGGING_LEVEL | default('INFO') }}
 
 kafka:
   bootstrap.servers: {{ KAFKA_URI | default('kafka:9092') }}

--- a/monasca-aggregator/config.yaml.j2
+++ b/monasca-aggregator/config.yaml.j2
@@ -2,6 +2,7 @@ windowSize: {{ AGGREGATION_WINDOW_SIZE | default('10') }}
 windowLag: {{ AGGREGATION_WINDOW_LAG | default('2') }}
 consumerTopic: {{ AGGREGATION_CONSUMER_TOPIC | default('metrics') }}
 producerTopic: {{ AGGREGATION_PRODUCER_TOPIC | default('metrics') }}
+logging.level: {{LOGGING_LEVEL | default('warning') }}
 
 kafka:
   bootstrap.servers: {{ KAFKA_URI | default('kafka:9092') }}

--- a/monasca-aggregator/config.yaml.j2
+++ b/monasca-aggregator/config.yaml.j2
@@ -3,7 +3,7 @@ windowLag: {{ AGGREGATION_WINDOW_LAG | default('2') }}
 consumerTopic: {{ AGGREGATION_CONSUMER_TOPIC | default('metrics') }}
 producerTopic: {{ AGGREGATION_PRODUCER_TOPIC | default('metrics') }}
 logging:
-  level: {{ LOGGING_LEVEL | default('INFO') }}
+  level: {{ LOG_LEVEL | default('INFO') }}
 
 kafka:
   bootstrap.servers: {{ KAFKA_URI | default('kafka:9092') }}

--- a/monasca-aggregator/config.yaml.j2
+++ b/monasca-aggregator/config.yaml.j2
@@ -3,7 +3,7 @@ windowLag: {{ AGGREGATION_WINDOW_LAG | default('2') }}
 consumerTopic: {{ AGGREGATION_CONSUMER_TOPIC | default('metrics') }}
 producerTopic: {{ AGGREGATION_PRODUCER_TOPIC | default('metrics') }}
 logging:
-  level: {{LOGGING_LEVEL | default('INFO') }}
+  level: {{ LOGGING_LEVEL | default('INFO') }}
 
 kafka:
   bootstrap.servers: {{ KAFKA_URI | default('kafka:9092') }}


### PR DESCRIPTION
https://github.com/monasca/monasca-docker/issues/485

hello,aggregator can config log level in the config.yaml,but monasca-docker project lack of this property.this property should be available to users.