### PR TITLE
Update monasca-api to master and fix build

### DIFF
--- a/monasca-api-python/Dockerfile
+++ b/monasca-api-python/Dockerfile
@@ -40,7 +40,8 @@ ENV CONFIG_TEMPLATE=true \
 
 COPY apk_install.sh /apk.sh
 RUN /build.sh -r ${API_REPO} -b ${API_BRANCH} \
-  -q ${CONSTRAINTS_BRANCH} -d "gunicorn influxdb python-memcached Jinja2" && \
+  -q ${CONSTRAINTS_BRANCH} \
+  -d "pykafka gunicorn gevent influxdb python-memcached Jinja2" && \
   rm -rf /build.sh
 
 COPY api-* /etc/monasca/

--- a/monasca-api-python/build.yml
+++ b/monasca-api-python/build.yml
@@ -4,6 +4,6 @@ variants:
     aliases:
       - :master-{date}-{time}
     args:
-      API_BRANCH: refs/changes/63/417163/10
+      API_BRANCH: master
       CONSTRAINTS_BRANCH: master
-      TIMESTAMP_SLUG: 20170809-155207
+      TIMESTAMP_SLUG: 20171101-203444


### PR DESCRIPTION
Include missing dependencies. `pykafka` was removed from upper
constraints file.

Old code used for building monasca-api
https://review.openstack.org/#/c/417163 is not building anymore because
depended library included breaking changes.

Use newer version of monasca/python image.

Signed-off-by: Dobroslaw Zybort <dobroslaw.zybort@ts.fujitsu.com>