### PR TITLE
Force python 2.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 services:
   - docker
 language: python
+python: 2.7
 
 addons:
   apt:


### PR DESCRIPTION
Travis is showing:
This job ran using the default Python version, 
which will be updated to 3.6 on April 16th, 2019.
You can explicitly stay on the previous version
by specifying python: 2.7 in your .travis.yml.

Signed-off-by: Dobroslaw Zybort <dobroslaw.zybort@ts.fujitsu.com>