### PR TITLE
Remove old Docker tags from build scripts

### DIFF
--- a/monasca-api-python/build.yml
+++ b/monasca-api-python/build.yml
@@ -1,8 +1,6 @@
 repository: monasca/api
 variants:
-  - tag: master
-    aliases:
-      - :master-{date}-{time}
+  - tag: master-{date}-{time}
     args:
       API_BRANCH: master
       CONSTRAINTS_BRANCH: master

--- a/monasca-log-api/build.yml
+++ b/monasca-log-api/build.yml
@@ -1,46 +1,8 @@
 repository: monasca/log-api
 variants:
-  - tag: master
-    aliases:
-      - :master-{date}-{time}
+  - tag: master-{date}-{time}
     args:
       LOG_API_BRANCH: master
       PYTHON_VERSION: '2'
       TIMESTAMP_SLUG: 20170809-155207
       CONSTRAINTS_BRANCH: master
-
-  - tag: 2.2.3
-    aliases:
-      - :latest
-      - :2.2
-      - :2
-    args:
-      LOG_API_BRANCH: 2.2.1
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207
-      CONSTRAINTS_BRANCH: master
-  - tag: 2.1.0
-    aliases:
-      - :2.1
-    args:
-      LOG_API_BRANCH: 2.1.0
-      CONSTRAINTS_BRANCH: master
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207
-  - tag: 2.0.0
-    aliases:
-      - :2.0
-    args:
-      LOG_API_BRANCH: 2.0.0
-      CONSTRAINTS_BRANCH: master
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207
-
-  - tag: ocata
-    aliases:
-      - :ocata-{date}-{time}
-    args:
-      LOG_API_BRANCH: stable/ocata
-      CONSTRAINTS_BRANCH: stable/ocata
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207

--- a/monasca-notification/build.yml
+++ b/monasca-notification/build.yml
@@ -1,10 +1,7 @@
 repository: monasca/notification
 variants:
 
-  - tag: master
-    aliases:
-      - :latest
-      - :master-{date}-{time}
+  - tag: master-{date}-{time}
     args:
       NOTIFICATION_BRANCH: refs/changes/17/461917/3
       TIMESTAMP_SLUG: 20170809-155207

--- a/monasca-persister-python/build.yml
+++ b/monasca-persister-python/build.yml
@@ -1,41 +1,6 @@
 repository: monasca/persister
 variants:
-  - tag: 1.6.0-python
-    aliases:
-      - :latest
-      - :latest-python
-      - :1.6.0
-      - :1.6
-      - :1
-      - :1-python
-    args:
-      PERSISTER_BRANCH: 1.6.0
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207
-
-  - tag: 1.5.0-python
-    aliases:
-      - :1.5.0
-      - :1.5
-      - :1.5-python
-    args:
-      PERSISTER_BRANCH: 1.5.0
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207
-
-  - tag: ocata-python
-    aliases:
-      - :ocata
-    args:
-      PERSISTER_BRANCH: stable/ocata
-      PYTHON_VERSION: '2'
-      TIMESTAMP_SLUG: 20170809-155207
-      CONSTRAINTS_BRANCH: stable/ocata
-
-  - tag: master
-    aliases:
-      - :master-{date}-{time}
-      - :master-python
+  - tag: master-{date}-{time}
     args:
       PERSISTER_BRANCH: master
       PYTHON_VERSION: '2'


### PR DESCRIPTION
Old tags removed from:
- monasca-api-python
- monasca-log-api
- monasca-notification
- monasca-persister-python

This old tags are still available on Docker Hub, now this images are
build in Zuul every 24 h and available with `master` tag so remove
`master` tag from tags used in monasca/monasca-docker to avoid
collisions.

Signed-off-by: Dobroslaw Zybort <dobroslaw.zybort@ts.fujitsu.com>