### PR TITLE
So far use STORM_UI_HOST isn't suitable for docker, because container…

### DIFF
--- a/storm/templates/storm.yaml.j2
+++ b/storm/templates/storm.yaml.j2
@@ -43,7 +43,7 @@ nimbus.seeds:
 nimbus.thrift.port: {{ NIMBUS_THRIFT_PORT | default('6627') }}
 nimbus.childopts: "{{ NIMBUS_CHILDOPTS }}"
 
-ui.host: "{{ STORM_UI_HOST | default ('127.0.0.1') }}"
+ui.host: 0.0.0.0
 ui.port: {{ STORM_UI_PORT | default('8088') }}
 ui.childopts: "{{ STORM_UI_CHILDOPTS }}"
 


### PR DESCRIPTION
… ip will be changed. So it should expose address using 0.0.0.0