### PR TITLE
Remove master tag from monasca-thresh

### DIFF
--- a/monasca-thresh/build.yml
+++ b/monasca-thresh/build.yml
@@ -1,8 +1,5 @@
 repository: monasca/thresh
 variants:
-  - tag: master
-    aliases:
-      - :master-{date}-{time}
-      - :latest
+  - tag: master-{date}-{time}
     args:
       SKIP_COMMON_TESTS: "true"


### PR DESCRIPTION
`master` tag will be overwritten by image coming from openstack repo.

Signed-off-by: Dobroslaw Zybort <dobroslaw.zybort@ts.fujitsu.com>