### PR TITLE
Update shellcheck URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - IGNORE_DOCKER_VERSION=true PYTHONUNBUFFERED=true SCVERSION=stable
 
 before_install:
-  - wget "https://storage.googleapis.com/shellcheck/shellcheck-$SCVERSION.linux.x86_64.tar.xz"
+  - wget "https://github.com/koalaman/shellcheck/releases/download/$SCVERSION/shellcheck-$SCVERSION.linux.x86_64.tar.xz"
   - tar --xz -xvf "shellcheck-$SCVERSION.linux.x86_64.tar.xz"
   - shellcheck() { "shellcheck-$SCVERSION/shellcheck" "$@"; }
   - shellcheck --version


### PR DESCRIPTION
This is the output using the outdated URL:

```
$ wget "https://storage.googleapis.com/shellcheck/shellcheck-$SCVERSION.linux.x86_64.tar.xz"
--2020-06-03 06:43:52--  https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz
Resolving storage.googleapis.com (storage.googleapis.com)... 172.217.204.128, 2607:f8b0:400c:c07::80
Connecting to storage.googleapis.com (storage.googleapis.com)|172.217.204.128|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 540 [application/x-xz]
Saving to: ‘shellcheck-stable.linux.x86_64.tar.xz’
     0K                                                       100% 99.5M=0s
2020-06-03 06:43:52 (99.5 MB/s) - ‘shellcheck-stable.linux.x86_64.tar.xz’ saved [540/540]
before_install.2
0.01s$ tar --xz -xvf "shellcheck-$SCVERSION.linux.x86_64.tar.xz"
before_install.3
0.00s$ shellcheck() { "shellcheck-$SCVERSION/shellcheck" "$@"; }
0.01s$ shellcheck --version
You are downloading ShellCheck from an outdated URL!
Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
For more information, see:
koalaman/shellcheck#1871
PS: Sorry for breaking your build :(
```

Signed-off-by: Martin Chacon Piza <MartinDavid.ChaconPiza1@est.fujitsu.com>